### PR TITLE
fix(validators): Add validation for duplicate step IDs within GitHub Actions jobs

### DIFF
--- a/crates/ui/src/components/button.rs
+++ b/crates/ui/src/components/button.rs
@@ -35,7 +35,7 @@ impl Button {
     }
 
     /// Render the button
-    pub fn render(&self) -> Paragraph {
+    pub fn render(&self) -> Paragraph<'_> {
         let (fg, bg) = match (self.is_selected, self.is_active) {
             (true, true) => (Color::Black, Color::Yellow),
             (true, false) => (Color::Black, Color::DarkGray),

--- a/crates/ui/src/components/checkbox.rs
+++ b/crates/ui/src/components/checkbox.rs
@@ -40,7 +40,7 @@ impl Checkbox {
     }
 
     /// Render the checkbox
-    pub fn render(&self) -> Paragraph {
+    pub fn render(&self) -> Paragraph<'_> {
         let checkbox = if self.is_checked { "[✓]" } else { "[ ]" };
 
         let style = if self.is_selected {

--- a/crates/ui/src/components/progress_bar.rs
+++ b/crates/ui/src/components/progress_bar.rs
@@ -39,7 +39,7 @@ impl ProgressBar {
     }
 
     /// Render the progress bar
-    pub fn render(&self) -> Gauge {
+    pub fn render(&self) -> Gauge<'_> {
         let label = match &self.label {
             Some(lbl) => format!("{} {:.0}%", lbl, self.progress * 100.0),
             None => format!("{:.0}%", self.progress * 100.0),

--- a/crates/ui/src/handlers/workflow.rs
+++ b/crates/ui/src/handlers/workflow.rs
@@ -262,7 +262,7 @@ pub async fn execute_workflow_cli(
         Err(e) => {
             println!("❌ Failed to execute workflow: {}", e);
             logging::error(&format!("Failed to execute workflow: {}", e));
-            Err(io::Error::new(io::ErrorKind::Other, e))
+            Err(io::Error::other(e))
         }
     }
 }

--- a/crates/ui/src/handlers/workflow.rs
+++ b/crates/ui/src/handlers/workflow.rs
@@ -95,10 +95,10 @@ pub async fn execute_workflow_cli(
             }
         }
         Err(e) => {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Error validating workflow: {}", e),
-            ));
+            return Err(io::Error::other(format!(
+                "Error validating workflow: {}",
+                e
+            )));
         }
     }
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -58,7 +58,7 @@ pub mod fd {
             // Duplicate the current stderr fd
             let stderr_backup = match dup(STDERR_FILENO) {
                 Ok(fd) => fd,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+                Err(e) => return Err(io::Error::other(e)),
             };
 
             // Open /dev/null
@@ -66,7 +66,7 @@ pub mod fd {
                 Ok(fd) => fd,
                 Err(e) => {
                     let _ = close(stderr_backup); // Clean up on error
-                    return Err(io::Error::new(io::ErrorKind::Other, e));
+                    return Err(io::Error::other(e));
                 }
             };
 
@@ -74,7 +74,7 @@ pub mod fd {
             if let Err(e) = dup2(null_fd, STDERR_FILENO) {
                 let _ = close(stderr_backup); // Clean up on error
                 let _ = close(null_fd);
-                return Err(io::Error::new(io::ErrorKind::Other, e));
+                return Err(io::Error::other(e));
             }
 
             Ok(RedirectedStderr {

--- a/crates/validators/src/steps.rs
+++ b/crates/validators/src/steps.rs
@@ -1,8 +1,11 @@
 use crate::validate_action_reference;
 use models::ValidationResult;
 use serde_yaml::Value;
+use std::collections::HashSet;
 
 pub fn validate_steps(steps: &[Value], job_name: &str, result: &mut ValidationResult) {
+    let mut step_ids: HashSet<String> = HashSet::new();
+
     for (i, step) in steps.iter().enumerate() {
         if let Some(step_map) = step.as_mapping() {
             if !step_map.contains_key(Value::String("name".to_string()))
@@ -25,6 +28,18 @@ pub fn validate_steps(steps: &[Value], job_name: &str, result: &mut ValidationRe
                     job_name,
                     i + 1
                 ));
+            }
+
+            // Check for duplicate step IDs
+            if let Some(Value::String(id)) = step_map.get(Value::String("id".to_string())) {
+                if !step_ids.insert(id.clone()) {
+                    result.add_issue(format!(
+                        "Job '{}', step {}: The identifier '{}' may not be used more than once within the same scope",
+                        job_name,
+                        i + 1,
+                        id
+                    ));
+                }
             }
 
             // Validate action reference if 'uses' is present


### PR DESCRIPTION
GitHub Actions requires step IDs to be unique within each job scope, but wrkflw was not validating this constraint. This caused workflows with duplicate step IDs to pass validation with exit code 0, while GitHub would reject them with "The identifier 'X' may not be used more than once within the same scope".

- Add HashSet tracking of step IDs in validate_steps()
- Check for duplicate IDs and report validation errors
- Use GitHub's exact error message format for consistency
- Step IDs can still be duplicated across different jobs (which is valid)

Fixes the validation gap that allowed invalid workflows to pass undetected.