### PR TITLE
feat: add --preserve-containers-on-failure flag for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ wrkflw run --emulate .github/workflows/ci.yml
 
 # Run with verbose output
 wrkflw run --verbose .github/workflows/ci.yml
+
+# Preserve failed containers for debugging
+wrkflw run --preserve-containers-on-failure .github/workflows/ci.yml
 ```
 
 ### Using the TUI Interface
@@ -222,6 +225,23 @@ WRKFLW supports composite actions, which are actions made up of multiple steps. 
 ### Container Cleanup
 
 WRKFLW automatically cleans up any Docker containers created during workflow execution, even if the process is interrupted with Ctrl+C.
+
+For debugging failed workflows, you can preserve containers that fail by using the `--preserve-containers-on-failure` flag:
+
+```bash
+# Preserve failed containers for debugging
+wrkflw run --preserve-containers-on-failure .github/workflows/build.yml
+
+# Also available in TUI mode
+wrkflw tui --preserve-containers-on-failure
+```
+
+When a container fails with this flag enabled, WRKFLW will:
+- Keep the failed container running instead of removing it
+- Log the container ID and provide inspection instructions
+- Show a message like: `Preserving container abc123 for debugging (exit code: 1). Use 'docker exec -it abc123 bash' to inspect.`
+
+This allows you to inspect the exact state of the container when the failure occurred, examine files, check environment variables, and debug issues more effectively.
 
 ## Limitations
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -10,4 +10,6 @@ pub mod substitution;
 
 // Re-export public items
 pub use docker::cleanup_resources;
-pub use engine::{execute_workflow, JobResult, JobStatus, RuntimeType, StepResult, StepStatus};
+pub use engine::{
+    execute_workflow, ExecutionConfig, JobResult, JobStatus, RuntimeType, StepResult, StepStatus,
+};

--- a/crates/ui/src/app/mod.rs
+++ b/crates/ui/src/app/mod.rs
@@ -26,6 +26,7 @@ pub async fn run_wrkflw_tui(
     path: Option<&PathBuf>,
     runtime_type: RuntimeType,
     verbose: bool,
+    preserve_containers_on_failure: bool,
 ) -> io::Result<()> {
     // Terminal setup
     enable_raw_mode()?;
@@ -41,7 +42,11 @@ pub async fn run_wrkflw_tui(
     ) = mpsc::channel();
 
     // Initialize app state
-    let mut app = App::new(runtime_type.clone(), tx.clone());
+    let mut app = App::new(
+        runtime_type.clone(),
+        tx.clone(),
+        preserve_containers_on_failure,
+    );
 
     if app.validation_mode {
         app.logs.push("Starting in validation mode".to_string());

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -19,6 +19,7 @@ pub struct App {
     pub show_help: bool,
     pub runtime_type: RuntimeType,
     pub validation_mode: bool,
+    pub preserve_containers_on_failure: bool,
     pub execution_queue: Vec<usize>, // Indices of workflows to execute
     pub current_execution: Option<usize>,
     pub logs: Vec<String>,                    // Overall execution logs
@@ -42,7 +43,11 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(runtime_type: RuntimeType, tx: mpsc::Sender<ExecutionResultMsg>) -> App {
+    pub fn new(
+        runtime_type: RuntimeType,
+        tx: mpsc::Sender<ExecutionResultMsg>,
+        preserve_containers_on_failure: bool,
+    ) -> App {
         let mut workflow_list_state = ListState::default();
         workflow_list_state.select(Some(0));
 
@@ -119,6 +124,7 @@ impl App {
             show_help: false,
             runtime_type,
             validation_mode: false,
+            preserve_containers_on_failure,
             execution_queue: Vec::new(),
             current_execution: None,
             logs: initial_logs,


### PR DESCRIPTION
- Add CLI flag to preserve Docker containers when tasks fail
- Create ExecutionConfig structure to pass configuration through system
- Modify DockerRuntime to conditionally skip container cleanup on failure
- Add support for both CLI run and TUI modes
- Log helpful debugging messages with container ID and inspection commands
- Preserve containers only when exit_code != 0 and flag is enabled
- Untrack preserved containers from automatic cleanup system

Fixes issue where failed containers were always deleted, preventing users from inspecting the actual state when debugging workflow failures.