### PR TITLE
feat: add execution support for reusable workflows

### DIFF
--- a/crates/parser/src/gitlab.rs
+++ b/crates/parser/src/gitlab.rs
@@ -130,7 +130,7 @@ pub fn convert_to_workflow_format(pipeline: &Pipeline) -> workflow::WorkflowDefi
 
         // Create a new job
         let mut job = workflow::Job {
-            runs_on: "ubuntu-latest".to_string(), // Default runner
+            runs_on: Some("ubuntu-latest".to_string()), // Default runner
             needs: None,
             steps: Vec::new(),
             env: HashMap::new(),
@@ -139,6 +139,9 @@ pub fn convert_to_workflow_format(pipeline: &Pipeline) -> workflow::WorkflowDefi
             if_condition: None,
             outputs: None,
             permissions: None,
+            uses: None,
+            with: None,
+            secrets: None,
         };
 
         // Add job-specific environment variables
@@ -230,13 +233,13 @@ pub fn convert_to_workflow_format(pipeline: &Pipeline) -> workflow::WorkflowDefi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    // use std::path::PathBuf; // unused
     use tempfile::NamedTempFile;
 
     #[test]
     fn test_parse_simple_pipeline() {
         // Create a temporary file with a simple GitLab CI/CD pipeline
-        let mut file = NamedTempFile::new().unwrap();
+        let file = NamedTempFile::new().unwrap();
         let content = r#"
 stages:
   - build

--- a/crates/parser/src/workflow.rs
+++ b/crates/parser/src/workflow.rs
@@ -39,9 +39,10 @@ pub struct WorkflowDefinition {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Job {
     #[serde(rename = "runs-on")]
-    pub runs_on: String,
+    pub runs_on: Option<String>,
     #[serde(default, deserialize_with = "deserialize_needs")]
     pub needs: Option<Vec<String>>,
+    #[serde(default)]
     pub steps: Vec<Step>,
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -55,6 +56,13 @@ pub struct Job {
     pub outputs: Option<HashMap<String, String>>,
     #[serde(default)]
     pub permissions: Option<HashMap<String, String>>,
+    // Reusable workflow (job-level 'uses') support
+    #[serde(default)]
+    pub uses: Option<String>,
+    #[serde(default)]
+    pub with: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub secrets: Option<serde_yaml::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/tests/reusable_workflow_execution_test.rs
+++ b/tests/reusable_workflow_execution_test.rs
@@ -1,0 +1,120 @@
+use std::fs;
+use tempfile::tempdir;
+use wrkflw::executor::engine::{execute_workflow, ExecutionConfig, RuntimeType};
+
+fn write_file(path: &std::path::Path, content: &str) {
+    fs::write(path, content).expect("failed to write file");
+}
+
+#[tokio::test]
+async fn test_local_reusable_workflow_execution_success() {
+    // Create temp workspace
+    let dir = tempdir().unwrap();
+    let called_path = dir.path().join("called.yml");
+    let caller_path = dir.path().join("caller.yml");
+
+    // Minimal called workflow with one successful job
+    let called = r#"
+name: Called
+on: workflow_dispatch
+jobs:
+  inner:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello from called"
+"#;
+    write_file(&called_path, called);
+
+    // Caller workflow that uses the called workflow via absolute local path
+    let caller = format!(
+        r#"
+name: Caller
+on: workflow_dispatch
+jobs:
+  call:
+    uses: {}
+    with:
+      foo: bar
+    secrets:
+      token: testsecret
+"#,
+        called_path.display()
+    );
+    write_file(&caller_path, &caller);
+
+    // Execute caller workflow with emulation runtime
+    let cfg = ExecutionConfig {
+        runtime_type: RuntimeType::Emulation,
+        verbose: false,
+        preserve_containers_on_failure: false,
+    };
+
+    let result = execute_workflow(&caller_path, cfg)
+        .await
+        .expect("workflow execution failed");
+
+    // Expect a single caller job summarized
+    assert_eq!(result.jobs.len(), 1, "expected one caller job result");
+    let job = &result.jobs[0];
+    assert_eq!(job.name, "call");
+    assert_eq!(format!("{:?}", job.status), "Success");
+
+    // Summary step should include reference to called workflow and inner job status
+    assert!(job
+        .logs
+        .contains("Called workflow:"),
+        "expected summary logs to include called workflow path");
+    assert!(job.logs.contains("- inner: Success"), "expected inner job success in summary");
+}
+
+#[tokio::test]
+async fn test_local_reusable_workflow_execution_failure_propagates() {
+    // Create temp workspace
+    let dir = tempdir().unwrap();
+    let called_path = dir.path().join("called.yml");
+    let caller_path = dir.path().join("caller.yml");
+
+    // Called workflow with failing job
+    let called = r#"
+name: Called
+on: workflow_dispatch
+jobs:
+  inner:
+    runs-on: ubuntu-latest
+    steps:
+      - run: false
+"#;
+    write_file(&called_path, called);
+
+    // Caller workflow
+    let caller = format!(
+        r#"
+name: Caller
+on: workflow_dispatch
+jobs:
+  call:
+    uses: {}
+"#,
+        called_path.display()
+    );
+    write_file(&caller_path, &caller);
+
+    // Execute caller workflow
+    let cfg = ExecutionConfig {
+        runtime_type: RuntimeType::Emulation,
+        verbose: false,
+        preserve_containers_on_failure: false,
+    };
+
+    let result = execute_workflow(&caller_path, cfg)
+        .await
+        .expect("workflow execution failed");
+
+    assert_eq!(result.jobs.len(), 1);
+    let job = &result.jobs[0];
+    assert_eq!(job.name, "call");
+    assert_eq!(format!("{:?}", job.status), "Failure");
+    assert!(job.logs.contains("- inner: Failure"));
+}
+
+


### PR DESCRIPTION
 (jobs.<id>.uses)\n\n- Parser: make jobs.runs-on optional; add job-level uses/with/secrets for caller jobs\n- Executor: resolve and run local/remote called workflows; propagate inputs/secrets; summarize results\n- Docs: document feature, usage, and current limits in README\n- Tests: add execution tests for local reusable workflows (success/failure)\n\nLimits:\n- Does not propagate outputs back to caller\n- secrets: inherit not special-cased; use mapping\n- Remote private repos not yet supported; public only\n- Cycle detection for nested calls unchanged