### PR TITLE
fix: Support array format for runs-on field in GitHub Actions workflows

### DIFF
--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -1762,9 +1762,13 @@ fn get_runner_image(runs_on: &str) -> String {
     .to_string()
 }
 
-fn get_runner_image_from_opt(runs_on: &Option<String>) -> String {
+fn get_runner_image_from_opt(runs_on: &Option<Vec<String>>) -> String {
     let default = "ubuntu-latest";
-    let ro = runs_on.as_deref().unwrap_or(default);
+    let ro = runs_on
+        .as_ref()
+        .and_then(|vec| vec.first())
+        .map(|s| s.as_str())
+        .unwrap_or(default);
     get_runner_image(ro)
 }
 

--- a/crates/parser/src/gitlab.rs
+++ b/crates/parser/src/gitlab.rs
@@ -130,7 +130,7 @@ pub fn convert_to_workflow_format(pipeline: &Pipeline) -> workflow::WorkflowDefi
 
         // Create a new job
         let mut job = workflow::Job {
-            runs_on: Some("ubuntu-latest".to_string()), // Default runner
+            runs_on: Some(vec!["ubuntu-latest".to_string()]), // Default runner
             needs: None,
             steps: Vec::new(),
             env: HashMap::new(),

--- a/tests/workflows/runs-on-array-test.yml
+++ b/tests/workflows/runs-on-array-test.yml
@@ -1,0 +1,18 @@
+name: Test Runs-On Array Format
+
+on: [push]
+
+jobs:
+  test-array-runs-on:
+    timeout-minutes: 15
+    runs-on: [self-hosted, ubuntu, small]
+    steps:
+      - name: Test step
+        run: echo "Testing array format for runs-on"
+
+  test-string-runs-on:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test step
+        run: echo "Testing string format for runs-on"


### PR DESCRIPTION
- Add custom deserializer for runs-on field to handle both string and array formats
- Update Job struct to use Vec<String> instead of String for runs-on field
- Modify executor to extract first element from runs-on array for runner selection
- Add test workflow to verify both string and array formats work correctly
- Maintain backwards compatibility with existing string-based workflows

Fixes issue where workflows with runs-on: [self-hosted, ubuntu, small] format
would fail with 'invalid type: sequence, expected a string' error.

This change aligns with GitHub Actions specification which supports:
- String format: runs-on: ubuntu-latest
- Array format: runs-on: [self-hosted, ubuntu, small]