### PR TITLE
fix: allow empty trigger glob filters in workflow parser

### DIFF
--- a/crates/parser/src/github-workflow.json
+++ b/crates/parser/src/github-workflow.json
@@ -318,7 +318,7 @@
         "type": "string",
         "minLength": 1
       },
-      "minItems": 1
+      "minItems": 0
     },
     "machine": {
       "type": "string",
@@ -1591,20 +1591,28 @@
             "workflow_dispatch": {
               "$comment": "https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/",
               "description": "You can now create workflows that are manually triggered with the new workflow_dispatch event. You will then see a 'Run workflow' button on the Actions tab, enabling you to easily trigger a run.",
-              "properties": {
-                "inputs": {
-                  "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputs",
-                  "description": "Input parameters allow you to specify data that the action expects to use during runtime. GitHub stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommended using lowercase input ids.",
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
                   "type": "object",
-                  "patternProperties": {
-                    "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
-                      "$ref": "#/definitions/workflowDispatchInput"
+                  "properties": {
+                    "inputs": {
+                      "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/metadata-syntax-for-github-actions#inputs",
+                      "description": "Input parameters allow you to specify data that the action expects to use during runtime. GitHub stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommended using lowercase input ids.",
+                      "type": "object",
+                      "patternProperties": {
+                        "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+                          "$ref": "#/definitions/workflowDispatchInput"
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
                 }
-              },
-              "additionalProperties": false
+              ]
             },
             "workflow_run": {
               "$comment": "https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run",

--- a/crates/parser/src/workflow.rs
+++ b/crates/parser/src/workflow.rs
@@ -190,3 +190,42 @@ fn normalize_triggers(on_value: &serde_yaml::Value) -> Result<Vec<String>, Strin
 
     Ok(triggers)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_workflow;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_workflow_allows_null_workflow_dispatch_with_other_triggers() {
+        let temp_dir = tempdir().unwrap();
+        let workflow_path = temp_dir.path().join("workflow.yml");
+
+        let content = r#"
+name: trigger-test
+on:
+  push:
+    branches: []
+    tags-ignore: []
+  release:
+    types: [prereleased, published]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"#;
+
+        fs::write(&workflow_path, content).unwrap();
+
+        let parsed = parse_workflow(&workflow_path);
+        assert!(
+            parsed.is_ok(),
+            "Expected workflow to parse successfully, got: {:?}",
+            parsed.err()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #64

This updates the bundled GitHub workflow JSON schema so trigger glob arrays (for keys like branches, branches-ignore, tags, tags-ignore, paths, and paths-ignore) can be empty.

Why:
- `wrkflw validate` accepted workflows with empty trigger filters, but `wrkflw run` failed during parser schema validation.
- GitHub accepts these workflows, so local execution should not reject them.

Also adds a parser unit test covering a workflow that mixes:
- push with empty branches/tags-ignore
- release trigger types
- workflow_dispatch

Verification:
- `~/.cargo/bin/cargo test -q -p wrkflw-parser`
- `~/.cargo/bin/cargo run -q -p wrkflw -- run --runtime emulation /tmp/wrkflw-repro/.github/workflows/trigger.yml`
