### PR TITLE
fix: prevent panic on single-char quoted values in env file parser

### DIFF
--- a/crates/secrets/src/providers/file.rs
+++ b/crates/secrets/src/providers/file.rs
@@ -82,9 +82,10 @@ impl FileProvider {
                 let key = key.trim().to_string();
                 let value = value.trim();
 
-                // Handle quoted values
-                let value = if (value.starts_with('"') && value.ends_with('"'))
-                    || (value.starts_with('\'') && value.ends_with('\''))
+                // Handle quoted values (length check prevents panic on single-char values like `"`)
+                let value = if value.len() >= 2
+                    && ((value.starts_with('"') && value.ends_with('"'))
+                        || (value.starts_with('\'') && value.ends_with('\'')))
                 {
                     &value[1..value.len() - 1]
                 } else {


### PR DESCRIPTION
## Summary
When an env file contains a value like `KEY="` (a single quote character), both `starts_with('"')` and `ends_with('"')` match on the same character. The slice `&value[1..value.len() - 1]` becomes `&value[1..0]`, which panics at runtime.

Added a `value.len() >= 2` guard before the quote-stripping logic.

## Test plan
- [ ] `KEY="value"` → `value` (unchanged behavior)
- [ ] `KEY="` → `"` (no longer panics)
- [ ] `KEY=''` → empty string (unchanged)
- [ ] `KEY=unquoted` → `unquoted` (unchanged)