### PR TITLE
fix(validators): reject non-mapping env values in validate

### DIFF
--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use wrkflw_models::ValidationResult;
-use wrkflw_validators::{validate_jobs, validate_triggers};
+use wrkflw_validators::{validate_env, validate_jobs, validate_triggers};
 
 pub fn evaluate_workflow_file(path: &Path, verbose: bool) -> Result<ValidationResult, String> {
     let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
@@ -37,6 +37,11 @@ pub fn evaluate_workflow_file(path: &Path, verbose: bool) -> Result<ValidationRe
         None => {
             result.add_issue("Workflow is missing 'jobs' section".to_string());
         }
+    }
+
+    // Validate top-level env is a mapping
+    if let Some(env) = workflow.get("env") {
+        validate_env(env, "Top-level", &mut result);
     }
 
     // Check for valid triggers

--- a/crates/validators/src/jobs.rs
+++ b/crates/validators/src/jobs.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use crate::{validate_matrix, validate_steps};
+use crate::{validate_env, validate_matrix, validate_steps};
 use serde_yaml::Value;
 use wrkflw_models::ValidationResult;
 
@@ -90,6 +90,11 @@ pub fn validate_jobs(jobs: &Value, repo_root: Option<&Path>, result: &mut Valida
                                 job_name, need
                             ));
                         }
+                    }
+
+                    // Validate env is a mapping, not a bare string
+                    if let Some(env_val) = job_config.get(Value::String("env".to_string())) {
+                        validate_env(env_val, &format!("Job '{}'", job_name), result);
                     }
 
                     // Validate matrix configuration if present
@@ -349,6 +354,51 @@ deploy:
                 .iter()
                 .any(|i| i.contains("Circular dependency")),
             "Valid DAG should not have cycle issues, got: {:?}",
+            result.issues
+        );
+    }
+
+    #[test]
+    fn test_job_env_string_is_invalid() {
+        let yaml = r#"
+build:
+  runs-on: ubuntu-latest
+  env: VAR=value
+  steps:
+    - run: echo build
+"#;
+        let jobs: Value = serde_yaml::from_str(yaml).unwrap();
+        let mut result = ValidationResult::new();
+        validate_jobs(&jobs, None, &mut result);
+
+        assert!(!result.is_valid);
+        assert!(
+            result
+                .issues
+                .iter()
+                .any(|i| i.contains("'env' must be a mapping")),
+            "Expected env mapping error, got: {:?}",
+            result.issues
+        );
+    }
+
+    #[test]
+    fn test_job_env_mapping_is_valid() {
+        let yaml = r#"
+build:
+  runs-on: ubuntu-latest
+  env:
+    MY_VAR: my_value
+  steps:
+    - run: echo build
+"#;
+        let jobs: Value = serde_yaml::from_str(yaml).unwrap();
+        let mut result = ValidationResult::new();
+        validate_jobs(&jobs, None, &mut result);
+
+        assert!(
+            !result.issues.iter().any(|i| i.contains("env")),
+            "Valid env mapping should not produce env issues, got: {:?}",
             result.issues
         );
     }

--- a/crates/validators/src/lib.rs
+++ b/crates/validators/src/lib.rs
@@ -13,3 +13,36 @@ pub use jobs::validate_jobs;
 pub use matrix::validate_matrix;
 pub use steps::validate_steps;
 pub use triggers::validate_triggers;
+
+use serde_yaml::Value;
+use wrkflw_models::ValidationResult;
+
+/// Check whether a YAML value is a string containing GitHub Actions expression syntax (`${{ }}`).
+fn is_expression_string(v: &Value) -> bool {
+    matches!(v, Value::String(s) if s.contains("${{") && s.contains("}}"))
+}
+
+/// Validate that an `env` value is a mapping (or an expression string).
+/// `context` describes where the env was found, e.g. "Job 'build'" or "Job 'build', step 3".
+pub fn validate_env(env: &Value, context: &str, result: &mut ValidationResult) {
+    if env.is_mapping() || is_expression_string(env) {
+        return;
+    }
+    let kind = yaml_type_name(env);
+    result.add_issue(format!(
+        "{}: 'env' must be a mapping of key-value pairs, not a {}",
+        context, kind
+    ));
+}
+
+fn yaml_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::String(_) => "string",
+        Value::Number(_) => "number",
+        Value::Bool(_) => "boolean",
+        Value::Sequence(_) => "sequence",
+        Value::Null => "null",
+        Value::Mapping(_) => "mapping",
+        Value::Tagged(_) => "tagged value",
+    }
+}

--- a/crates/validators/src/steps.rs
+++ b/crates/validators/src/steps.rs
@@ -1,4 +1,4 @@
-use crate::validate_action_reference;
+use crate::{validate_action_reference, validate_env};
 use serde_yaml::Value;
 use std::collections::HashSet;
 use std::path::Path;
@@ -48,6 +48,15 @@ pub fn validate_steps(
                 }
             }
 
+            // Validate env is a mapping, not a bare string
+            if let Some(env_val) = step_map.get(Value::String("env".to_string())) {
+                validate_env(
+                    env_val,
+                    &format!("Job '{}', step {}", job_name, i + 1),
+                    result,
+                );
+            }
+
             // Validate action reference if 'uses' is present
             if let Some(Value::String(uses)) = step_map.get(Value::String("uses".to_string())) {
                 let with_params = step_map
@@ -91,6 +100,55 @@ mod tests {
         let yaml = r#"
 - name: "build"
   run: "cargo build"
+"#;
+        let steps: Vec<Value> = serde_yaml::from_str(yaml).unwrap();
+        let mut result = ValidationResult::new();
+        validate_steps(&steps, "test-job", None, &mut result);
+
+        assert!(result.is_valid);
+        assert!(result.issues.is_empty());
+    }
+
+    #[test]
+    fn test_step_env_string_is_invalid() {
+        let yaml = r#"
+- name: "build"
+  run: "cargo build"
+  env: VAR=value
+"#;
+        let steps: Vec<Value> = serde_yaml::from_str(yaml).unwrap();
+        let mut result = ValidationResult::new();
+        validate_steps(&steps, "test-job", None, &mut result);
+
+        assert!(!result.is_valid);
+        assert!(result
+            .issues
+            .iter()
+            .any(|i| i.contains("'env' must be a mapping")));
+    }
+
+    #[test]
+    fn test_step_env_mapping_is_valid() {
+        let yaml = r#"
+- name: "build"
+  run: "cargo build"
+  env:
+    MY_VAR: my_value
+"#;
+        let steps: Vec<Value> = serde_yaml::from_str(yaml).unwrap();
+        let mut result = ValidationResult::new();
+        validate_steps(&steps, "test-job", None, &mut result);
+
+        assert!(result.is_valid);
+        assert!(result.issues.is_empty());
+    }
+
+    #[test]
+    fn test_step_env_expression_is_valid() {
+        let yaml = r#"
+- name: "build"
+  run: "cargo build"
+  env: ${{ fromJSON(needs.setup.outputs.env) }}
 "#;
         let steps: Vec<Value> = serde_yaml::from_str(yaml).unwrap();
         let mut result = ValidationResult::new();


### PR DESCRIPTION
## Summary

- `wrkflw validate` now rejects `env: VAR=value` (bare strings) at step, job, and top-level — GitHub Actions only accepts mappings for `env:`
- Expression strings like `env: ${{ fromJSON(...) }}` are still allowed
- Adds `validate_env()` helper in the validators crate, wired into `validate_steps`, `validate_jobs`, and `evaluate_workflow_file`

Closes #89

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo test -p wrkflw-validators` — 30 tests pass (6 new)
- [x] `cargo test -p wrkflw-evaluator` — passes
- [x] Full `cargo test` — all green
- [x] End-to-end: `wrkflw validate` rejects `env: VAR=value` at step, job, and top level
- [x] End-to-end: `wrkflw validate` accepts proper `env:` mappings