### PR TITLE
fix(executor): populate workflow-level env in expression context

### DIFF
--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -106,6 +106,11 @@ async fn execute_github_workflow(
     // 4. Set up GitHub-like environment
     let mut env_context = environment::create_github_context(&workflow, workspace_dir.path());
 
+    // Add workflow-level environment variables (lowest precedence — job and step env override)
+    for (key, value) in &workflow.env {
+        env_context.insert(key.clone(), value.clone());
+    }
+
     // Add runtime mode to environment
     env_context.insert(
         "WRKFLW_RUNTIME_MODE".to_string(),
@@ -4585,6 +4590,7 @@ async fn execute_composite_action(
                         on_raw: serde_yaml::Value::Null,
                         jobs: HashMap::new(),
                         defaults: None,
+                        env: HashMap::new(),
                     },
                     runner_image,
                     verbose,
@@ -5501,6 +5507,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: HashMap::new(),
             defaults: None,
+            env: HashMap::new(),
         }
     }
 
@@ -6036,6 +6043,7 @@ runs:
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         }
     }
 

--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -106,9 +106,36 @@ async fn execute_github_workflow(
     // 4. Set up GitHub-like environment
     let mut env_context = environment::create_github_context(&workflow, workspace_dir.path());
 
-    // Add workflow-level environment variables (lowest precedence — job and step env override)
-    for (key, value) in &workflow.env {
-        env_context.insert(key.clone(), value.clone());
+    // Add workflow-level environment variables (lowest precedence — does not override
+    // built-in GITHUB_*/RUNNER_* vars; job and step env override these later).
+    // Resolve ${{ }} expressions (e.g. ${{ github.repository }}) in values.
+    {
+        let wf_expr_ctx = crate::expression::ExpressionContext {
+            env_context: &env_context,
+            step_outputs: &HashMap::new(),
+            matrix_combination: &None,
+            step_statuses: &HashMap::new(),
+            job_status: "success",
+            secrets_context: &HashMap::new(),
+            needs_context: &HashMap::new(),
+            needs_results: &HashMap::new(),
+        };
+        let cwd = std::env::current_dir().map_err(|e| {
+            ExecutionError::Execution(format!("Failed to get current directory: {}", e))
+        })?;
+        let resolved_env: Vec<(String, String)> = workflow
+            .env
+            .iter()
+            .map(|(key, value)| {
+                let resolved =
+                    crate::substitution::preprocess_expressions(value, &cwd, &wf_expr_ctx)
+                        .unwrap_or_else(|_| value.clone());
+                (key.clone(), resolved)
+            })
+            .collect();
+        for (key, value) in resolved_env {
+            env_context.entry(key).or_insert(value);
+        }
     }
 
     // Add runtime mode to environment
@@ -5496,6 +5523,94 @@ mod tests {
         assert_eq!(job_env.get("CONTAINER_ONLY").unwrap(), "container-value");
         // Job-only keys are preserved
         assert_eq!(job_env.get("JOB_ONLY").unwrap(), "job-value");
+    }
+
+    // --- workflow-level env tests ---
+
+    #[test]
+    fn workflow_env_does_not_override_builtin_github_vars() {
+        // Workflow-level env uses entry().or_insert(), so it must NOT override
+        // built-in GITHUB_* variables set by create_github_context().
+        let mut env_context: HashMap<String, String> = HashMap::from([
+            ("GITHUB_SHA".into(), "abc123".into()),
+            ("CI".into(), "true".into()),
+        ]);
+
+        // Simulate workflow env with keys that collide with builtins
+        let workflow_env: HashMap<String, String> = HashMap::from([
+            ("GITHUB_SHA".into(), "should-not-win".into()),
+            ("CI".into(), "false".into()),
+            ("MY_CUSTOM_VAR".into(), "custom-value".into()),
+        ]);
+        for (key, value) in &workflow_env {
+            env_context
+                .entry(key.clone())
+                .or_insert_with(|| value.clone());
+        }
+
+        // Built-in values must be preserved
+        assert_eq!(env_context.get("GITHUB_SHA").unwrap(), "abc123");
+        assert_eq!(env_context.get("CI").unwrap(), "true");
+        // Custom workflow env is added
+        assert_eq!(env_context.get("MY_CUSTOM_VAR").unwrap(), "custom-value");
+    }
+
+    #[test]
+    fn workflow_env_overridden_by_job_env() {
+        // Precedence: workflow env (lowest) < job env < step env (highest)
+        let mut env_context: HashMap<String, String> = HashMap::new();
+
+        // Step 1: workflow env (lowest precedence)
+        let workflow_env: HashMap<String, String> = HashMap::from([
+            ("SHARED".into(), "from-workflow".into()),
+            ("WF_ONLY".into(), "workflow-value".into()),
+        ]);
+        for (key, value) in &workflow_env {
+            env_context
+                .entry(key.clone())
+                .or_insert_with(|| value.clone());
+        }
+
+        // Step 2: job env (overrides workflow env)
+        let job_env: HashMap<String, String> = HashMap::from([
+            ("SHARED".into(), "from-job".into()),
+            ("JOB_ONLY".into(), "job-value".into()),
+        ]);
+        for (key, value) in &job_env {
+            env_context.insert(key.clone(), value.clone());
+        }
+
+        // Job env wins for shared keys
+        assert_eq!(env_context.get("SHARED").unwrap(), "from-job");
+        // Workflow-only keys are preserved
+        assert_eq!(env_context.get("WF_ONLY").unwrap(), "workflow-value");
+        // Job-only keys are preserved
+        assert_eq!(env_context.get("JOB_ONLY").unwrap(), "job-value");
+    }
+
+    #[test]
+    fn workflow_env_expression_substitution() {
+        // Workflow-level env values containing ${{ }} expressions should be resolved
+        let env_context: HashMap<String, String> =
+            HashMap::from([("GITHUB_REPOSITORY".into(), "owner/repo".into())]);
+        let expr_ctx = crate::expression::ExpressionContext {
+            env_context: &env_context,
+            step_outputs: &HashMap::new(),
+            matrix_combination: &None,
+            step_statuses: &HashMap::new(),
+            job_status: "success",
+            secrets_context: &HashMap::new(),
+            needs_context: &HashMap::new(),
+            needs_results: &HashMap::new(),
+        };
+        let cwd = std::env::current_dir().unwrap();
+
+        // Simulate a workflow env value with an expression
+        let raw_value = "repo=${{ github.repository }}";
+        let resolved = crate::substitution::preprocess_expressions(raw_value, &cwd, &expr_ctx)
+            .unwrap_or_else(|_| raw_value.to_string());
+
+        assert_eq!(resolved, "repo=owner/repo");
     }
 
     // --- evaluate_job_condition tests for step-level expressions ---

--- a/crates/parser/src/gitlab.rs
+++ b/crates/parser/src/gitlab.rs
@@ -120,6 +120,7 @@ pub fn convert_to_workflow_format(pipeline: &Pipeline) -> workflow::WorkflowDefi
         on_raw: serde_yaml::Value::String("push".to_string()),
         jobs: HashMap::new(),
         defaults: None,
+        env: HashMap::new(),
     };
 
     // Convert each GitLab job to a GitHub Actions job

--- a/crates/parser/src/workflow.rs
+++ b/crates/parser/src/workflow.rs
@@ -146,6 +146,8 @@ pub struct WorkflowDefinition {
     pub jobs: HashMap<String, Job>,
     #[serde(default)]
     pub defaults: Option<Defaults>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -412,6 +414,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("actions/checkout@v4");
         assert_eq!(info.repository, "actions/checkout");
@@ -429,6 +432,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("owner/repo");
         assert_eq!(info.repository, "owner/repo");
@@ -444,6 +448,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("docker://alpine:3.18");
         assert_eq!(info.repository, "docker://alpine:3.18");
@@ -460,6 +465,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("./my-action");
         assert_eq!(info.repository, "./my-action");
@@ -476,6 +482,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         // Docker image references can use @sha256:digest — the full string is the image ref
         let info = wd.resolve_action("docker://alpine@sha256:abcdef1234567890");
@@ -493,6 +500,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675");
         assert_eq!(info.repository, "actions/checkout");
@@ -508,6 +516,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("owner/repo/path/to/action@v2");
         assert_eq!(info.repository, "owner/repo");
@@ -525,6 +534,7 @@ mod tests {
             on_raw: serde_yaml::Value::Null,
             jobs: Default::default(),
             defaults: None,
+            env: HashMap::new(),
         };
         let info = wd.resolve_action("github/codeql-action/init@v3");
         assert_eq!(info.repository, "github/codeql-action");

--- a/crates/trigger-filter/src/parser.rs
+++ b/crates/trigger-filter/src/parser.rs
@@ -900,6 +900,7 @@ pul_request:
             on_raw: make_on_raw("pul_request"),
             jobs: std::collections::HashMap::new(),
             defaults: None,
+            env: std::collections::HashMap::new(),
         };
         let mut cfg = parse_trigger_config(&wf, PathBuf::from("test.yml")).unwrap();
         // Drain explicitly so the MustDrainWarnings Drop check stays


### PR DESCRIPTION
## Summary

- `WorkflowDefinition` was missing an `env` field — serde silently discarded workflow-level `env:` during YAML deserialization
- `${{ env.GLOBAL_VAR }}` evaluated to empty string while `$GLOBAL_VAR` in shell worked fine, because the OS environment got the vars but the expression evaluator never did
- Added the `env` field to `WorkflowDefinition` and merged it into `env_context` right after `create_github_context()`, giving correct precedence: step > job > workflow (matching GitHub Actions)

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Verified end-to-end: `${{ env.ANOTHER_VAR }}` resolves workflow-level env correctly
- [x] Verified precedence: job-level `env` overrides workflow-level when both define the same key
- [x] CI passes