### PR TITLE
refactor(executor): separate user env from runner env in ExpressionContext

### DIFF
--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -110,6 +110,15 @@ async fn execute_github_workflow(
     // built-in GITHUB_*/RUNNER_* vars; job and step env override these later).
     // Resolve ${{ }} expressions (e.g. ${{ github.repository }}) in values.
     {
+        // Bridge: user_env is derived from env_context via the legacy heuristic filter.
+        // Commit 2 replaces this with an authoritatively-tracked user_env built from
+        // workflow/job/step env merges. Workflow.env hasn't been merged yet here, so
+        // in practice this map is empty.
+        let user_env: HashMap<String, String> = env_context
+            .iter()
+            .filter(|(k, _)| crate::expression::is_user_env_var(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         let wf_expr_ctx = crate::expression::ExpressionContext {
             env_context: &env_context,
             step_outputs: &HashMap::new(),
@@ -119,6 +128,7 @@ async fn execute_github_workflow(
             secrets_context: &HashMap::new(),
             needs_context: &HashMap::new(),
             needs_results: &HashMap::new(),
+            user_env: &user_env,
         };
         let cwd = std::env::current_dir().map_err(|e| {
             ExecutionError::Execution(format!("Failed to get current directory: {}", e))
@@ -2150,6 +2160,13 @@ async fn execute_matrix_job(
     // We collect resolved values first to avoid borrowing job_env while mutating it.
     {
         let matrix_opt = Some(combination.values.clone());
+        // Bridge: derive user_env from the current job_env via the legacy heuristic.
+        // Commit 2 replaces this with an authoritatively-tracked job_user_env.
+        let user_env: HashMap<String, String> = job_env
+            .iter()
+            .filter(|(k, _)| crate::expression::is_user_env_var(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         let env_expr_ctx = crate::expression::ExpressionContext {
             env_context: &job_env,
             step_outputs: &HashMap::new(),
@@ -2159,6 +2176,7 @@ async fn execute_matrix_job(
             secrets_context: services.secrets_context,
             needs_context: services.needs_context,
             needs_results: services.needs_results,
+            user_env: &user_env,
         };
         let cwd = std::env::current_dir().map_err(|e| {
             ExecutionError::Execution(format!("Failed to get current directory: {}", e))
@@ -2567,7 +2585,8 @@ async fn run_step_with_guards(
 
     // Check step-level if condition
     if let Some(if_cond) = &step.if_condition {
-        let cond_ctx = step_exec_ctx.expr_context();
+        let mut user_env_buf = HashMap::new();
+        let cond_ctx = step_exec_ctx.expr_context(&mut user_env_buf);
         let should_run = evaluate_condition_with_context(if_cond, &cond_ctx);
         if !should_run {
             wrkflw_logging::info(&format!(
@@ -2690,8 +2709,25 @@ struct StepExecutionContext<'a> {
 }
 
 impl<'a> StepExecutionContext<'a> {
-    /// Build an `ExpressionContext` from this step context.
-    fn expr_context(&self) -> crate::expression::ExpressionContext<'_> {
+    /// Build an `ExpressionContext` from this step context. The returned context
+    /// borrows from `user_env_buf`, which the caller owns — this indirection lets
+    /// us return a `ExpressionContext<'b>` whose lifetime is tied to a caller-
+    /// provided buffer rather than `self` (which already borrows `job_env`).
+    ///
+    /// Bridge behavior (Commit 1): `user_env_buf` is populated by filtering
+    /// `job_env` through the legacy `is_user_env_var` heuristic. Commit 2
+    /// replaces this with an authoritatively-tracked `job_user_env` field on
+    /// `StepExecutionContext`.
+    fn expr_context<'b>(
+        &'b self,
+        user_env_buf: &'b mut HashMap<String, String>,
+    ) -> crate::expression::ExpressionContext<'b> {
+        *user_env_buf = self
+            .job_env
+            .iter()
+            .filter(|(k, _)| crate::expression::is_user_env_var(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         crate::expression::ExpressionContext {
             env_context: self.job_env,
             step_outputs: self.step_outputs,
@@ -2701,17 +2737,26 @@ impl<'a> StepExecutionContext<'a> {
             secrets_context: self.services.secrets_context,
             needs_context: self.services.needs_context,
             needs_results: self.services.needs_results,
+            user_env: user_env_buf,
         }
     }
 
     /// Build an `ExpressionContext` using a custom env (e.g. partially-built step env).
+    /// `user_env_buf` is filled with the user-declared slice of `env` and borrowed
+    /// by the returned context; callers must keep it alive alongside the context.
     fn expr_context_with_env<'e>(
         &self,
         env: &'e HashMap<String, String>,
+        user_env_buf: &'e mut HashMap<String, String>,
     ) -> crate::expression::ExpressionContext<'e>
     where
         'a: 'e,
     {
+        *user_env_buf = env
+            .iter()
+            .filter(|(k, _)| crate::expression::is_user_env_var(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         crate::expression::ExpressionContext {
             env_context: env,
             step_outputs: self.step_outputs,
@@ -2721,6 +2766,7 @@ impl<'a> StepExecutionContext<'a> {
             secrets_context: self.services.secrets_context,
             needs_context: self.services.needs_context,
             needs_results: self.services.needs_results,
+            user_env: user_env_buf,
         }
     }
 }
@@ -2730,7 +2776,8 @@ impl<'a> StepExecutionContext<'a> {
 /// On expression error, returns empty string (matching GitHub Actions behavior
 /// where unresolvable expressions resolve to empty).
 fn preprocess_with_value(value: &str, ctx: &StepExecutionContext<'_>) -> String {
-    let expr_ctx = ctx.expr_context();
+    let mut user_env_buf = HashMap::new();
+    let expr_ctx = ctx.expr_context(&mut user_env_buf);
     crate::substitution::preprocess_expressions(value, ctx.working_dir, &expr_ctx)
         .unwrap_or_default()
 }
@@ -3038,7 +3085,8 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
             value.clone()
         };
         // Resolve ${{ }} expressions in env values (e.g. ${{inputs.toolchain}})
-        let env_expr_ctx = ctx.expr_context_with_env(&step_env);
+        let mut user_env_buf = HashMap::new();
+        let env_expr_ctx = ctx.expr_context_with_env(&step_env, &mut user_env_buf);
         let resolved_value = match crate::substitution::preprocess_expressions(
             &resolved_value,
             ctx.working_dir,
@@ -3600,7 +3648,8 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
         };
 
         // Resolve expression substitutions (hashFiles, step outputs, env, matrix vars)
-        let run_expr_ctx = ctx.expr_context();
+        let mut user_env_buf = HashMap::new();
+        let run_expr_ctx = ctx.expr_context(&mut user_env_buf);
         let resolved_run = match crate::substitution::preprocess_expressions(
             &resolved_run,
             ctx.working_dir,
@@ -4773,6 +4822,12 @@ fn propagate_composite_outputs(
     let empty_secrets = HashMap::new();
     let empty_needs = HashMap::new();
     let empty_results = HashMap::new();
+    // Bridge: derive user_env from action_env via the legacy heuristic.
+    let user_env: HashMap<String, String> = action_env
+        .iter()
+        .filter(|(k, _)| crate::expression::is_user_env_var(k))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     let expr_ctx = crate::expression::ExpressionContext {
         env_context: action_env,
         step_outputs: composite_step_outputs,
@@ -4782,6 +4837,7 @@ fn propagate_composite_outputs(
         secrets_context: &empty_secrets,
         needs_context: &empty_needs,
         needs_results: &empty_results,
+        user_env: &user_env,
     };
 
     // Collect evaluated outputs
@@ -4965,6 +5021,12 @@ fn evaluate_job_condition(
     env_context: &HashMap<String, String>,
     _workflow: &WorkflowDefinition,
 ) -> bool {
+    // Bridge: derive user_env from env_context via the legacy heuristic.
+    let user_env: HashMap<String, String> = env_context
+        .iter()
+        .filter(|(k, _)| crate::expression::is_user_env_var(k))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
     let ctx = crate::expression::ExpressionContext {
         env_context,
         step_outputs: &HashMap::new(),
@@ -4974,6 +5036,7 @@ fn evaluate_job_condition(
         secrets_context: &HashMap::new(),
         needs_context: &HashMap::new(),
         needs_results: &HashMap::new(),
+        user_env: &user_env,
     };
     evaluate_condition_with_context(condition, &ctx)
 }
@@ -5046,6 +5109,12 @@ fn resolve_job_outputs(
 ) -> HashMap<String, String> {
     let mut resolved = HashMap::new();
     if let Some(outputs) = &job.outputs {
+        // Bridge: derive user_env from env_context via the legacy heuristic.
+        let user_env: HashMap<String, String> = env_context
+            .iter()
+            .filter(|(k, _)| crate::expression::is_user_env_var(k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         let ctx = crate::expression::ExpressionContext {
             env_context,
             step_outputs: step_outputs_map,
@@ -5055,6 +5124,7 @@ fn resolve_job_outputs(
             secrets_context: &HashMap::new(),
             needs_context: &HashMap::new(),
             needs_results: &HashMap::new(),
+            user_env: &user_env,
         };
         for (key, expr) in outputs {
             match crate::substitution::preprocess_expressions(expr, working_dir, &ctx) {
@@ -5593,6 +5663,7 @@ mod tests {
         // Workflow-level env values containing ${{ }} expressions should be resolved
         let env_context: HashMap<String, String> =
             HashMap::from([("GITHUB_REPOSITORY".into(), "owner/repo".into())]);
+        let empty_user_env = HashMap::new();
         let expr_ctx = crate::expression::ExpressionContext {
             env_context: &env_context,
             step_outputs: &HashMap::new(),
@@ -5602,6 +5673,7 @@ mod tests {
             secrets_context: &HashMap::new(),
             needs_context: &HashMap::new(),
             needs_results: &HashMap::new(),
+            user_env: &empty_user_env,
         };
         let cwd = std::env::current_dir().unwrap();
 
@@ -8154,6 +8226,7 @@ runs:
             secrets_context: &empty_secrets,
             needs_context: &needs_ctx,
             needs_results: &needs_res,
+            user_env: &empty_env,
         };
 
         // Test needs.build.outputs.artifact
@@ -8208,6 +8281,7 @@ runs:
             secrets_context: &empty_secrets,
             needs_context: &empty_needs,
             needs_results: &empty_needs_results,
+            user_env: &empty_env,
         };
 
         // outcome should be "failure" (raw result)
@@ -8249,6 +8323,7 @@ runs:
             secrets_context: &secrets,
             needs_context: &empty_needs,
             needs_results: &empty_needs_results,
+            user_env: &empty_env,
         };
 
         let result = crate::expression::evaluate("secrets.API_KEY", &ctx).unwrap();

--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -105,20 +105,17 @@ async fn execute_github_workflow(
 
     // 4. Set up GitHub-like environment
     let mut env_context = environment::create_github_context(&workflow, workspace_dir.path());
+    // Track the user-declared slice of env separately so `toJSON(env)` only
+    // dumps what the user actually wrote in YAML (and later, what steps write
+    // to `$GITHUB_ENV`). Starts empty — `create_github_context` only seeds
+    // runner-internal vars.
+    let mut user_env: HashMap<String, String> = HashMap::new();
 
     // Add workflow-level environment variables (lowest precedence — does not override
     // built-in GITHUB_*/RUNNER_* vars; job and step env override these later).
     // Resolve ${{ }} expressions (e.g. ${{ github.repository }}) in values.
     {
-        // Bridge: user_env is derived from env_context via the legacy heuristic filter.
-        // Commit 2 replaces this with an authoritatively-tracked user_env built from
-        // workflow/job/step env merges. Workflow.env hasn't been merged yet here, so
-        // in practice this map is empty.
-        let user_env: HashMap<String, String> = env_context
-            .iter()
-            .filter(|(k, _)| crate::expression::is_user_env_var(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        // At this point workflow.env hasn't been merged yet — user_env is empty.
         let wf_expr_ctx = crate::expression::ExpressionContext {
             env_context: &env_context,
             step_outputs: &HashMap::new(),
@@ -144,7 +141,14 @@ async fn execute_github_workflow(
             })
             .collect();
         for (key, value) in resolved_env {
-            env_context.entry(key).or_insert(value);
+            // `or_insert` semantics: workflow.env does not override runner-seeded
+            // vars. user_env mirrors the same precedence — a workflow.env key that
+            // collides with a runner var is dropped from env_context AND not added
+            // to user_env (real GHA doesn't let workflow.env shadow runner vars).
+            env_context.entry(key.clone()).or_insert_with(|| {
+                user_env.insert(key, value.clone());
+                value
+            });
         }
     }
 
@@ -220,6 +224,7 @@ async fn execute_github_workflow(
             &workflow,
             runtime.as_ref(),
             &env_context,
+            &user_env,
             config.verbose,
             secret_manager.as_ref(),
             Some(&secret_masker),
@@ -400,6 +405,9 @@ async fn execute_gitlab_pipeline(
             &workflow,
             runtime.as_ref(),
             &env_context,
+            // GitLab pipelines don't carry workflow-level `env:`, so user_env
+            // starts empty; it'll accumulate through job/step env merges.
+            &HashMap::new(),
             config.verbose,
             secret_manager.as_ref(),
             Some(&secret_masker),
@@ -1707,6 +1715,7 @@ async fn execute_job_batch(
     workflow: &WorkflowDefinition,
     runtime: &dyn ContainerRuntime,
     env_context: &HashMap<String, String>,
+    user_env: &HashMap<String, String>,
     verbose: bool,
     secret_manager: Option<&SecretManager>,
     secret_masker: Option<&SecretMasker>,
@@ -1722,6 +1731,7 @@ async fn execute_job_batch(
             workflow,
             runtime,
             env_context,
+            user_env,
             verbose,
             secret_manager,
             secret_masker,
@@ -1756,6 +1766,9 @@ struct JobExecutionContext<'a> {
     workflow: &'a WorkflowDefinition,
     runtime: &'a dyn ContainerRuntime,
     env_context: &'a HashMap<String, String>,
+    /// Workflow-level user-declared env only (runner-seeded vars excluded).
+    /// Consumed by `toJSON(env)` downstream. See `ExpressionContext::user_env`.
+    user_env: &'a HashMap<String, String>,
     verbose: bool,
     services: JobServices<'a>,
 }
@@ -1767,6 +1780,7 @@ async fn execute_job_with_matrix(
     workflow: &WorkflowDefinition,
     runtime: &dyn ContainerRuntime,
     env_context: &HashMap<String, String>,
+    user_env: &HashMap<String, String>,
     verbose: bool,
     secret_manager: Option<&SecretManager>,
     secret_masker: Option<&SecretMasker>,
@@ -1785,7 +1799,7 @@ async fn execute_job_with_matrix(
 
     // Evaluate job condition if present
     if let Some(if_condition) = &job.if_condition {
-        let should_run = evaluate_job_condition(if_condition, env_context, workflow);
+        let should_run = evaluate_job_condition(if_condition, env_context, user_env, workflow);
         if !should_run {
             wrkflw_logging::info(&format!(
                 "{} Skipping job '{}' due to condition: {}",
@@ -1862,6 +1876,7 @@ async fn execute_job_with_matrix(
             workflow,
             runtime,
             env_context,
+            user_env,
             verbose,
             services,
         })
@@ -1882,6 +1897,7 @@ async fn execute_job_with_matrix(
             workflow,
             runtime,
             env_context,
+            user_env,
             verbose,
             services,
         };
@@ -1903,23 +1919,32 @@ async fn execute_job(ctx: JobExecutionContext<'_>) -> Result<JobResult, Executio
             .await;
     }
 
-    // Clone context and add job-specific variables
+    // Clone context and add job-specific variables.
+    // `job_env` is the full lookup map (runner + user union); `job_user_env`
+    // mirrors only the user-declared slice for `toJSON(env)`.
     let mut job_env = ctx.env_context.clone();
+    let mut job_user_env = ctx.user_env.clone();
 
-    // Add container-level environment variables (lowest precedence)
+    // Add container-level environment variables (lowest precedence).
+    // Container env is user-declared (jobs.<id>.container.env in YAML) — mirror
+    // into job_user_env. Skip keys already present (`.entry().or_insert`).
     if let Some(ref container) = job.container {
         warn_unsupported_container_fields(container);
         for (key, value) in &container.env {
-            job_env.entry(key.clone()).or_insert_with(|| value.clone());
+            if !job_env.contains_key(key) {
+                job_env.insert(key.clone(), value.clone());
+                job_user_env.insert(key.clone(), value.clone());
+            }
         }
     }
 
-    // Add job-level environment variables (overrides container env)
+    // Add job-level environment variables (overrides container env).
     for (key, value) in &job.env {
         job_env.insert(key.clone(), value.clone());
+        job_user_env.insert(key.clone(), value.clone());
     }
 
-    // Add job-specific context
+    // Add job-specific context (runner-internal — GITHUB_JOB; not user env)
     environment::add_job_context(&mut job_env, ctx.job_name);
 
     // Create a temporary directory for this job execution
@@ -1962,6 +1987,7 @@ async fn execute_job(ctx: JobExecutionContext<'_>) -> Result<JobResult, Executio
                     step,
                     step_idx: idx,
                     job_env: &job_env,
+                    job_user_env: &job_user_env,
                     working_dir: job_dir.path(),
                     runtime: ctx.runtime,
                     workflow: ctx.workflow,
@@ -2007,6 +2033,7 @@ async fn execute_job(ctx: JobExecutionContext<'_>) -> Result<JobResult, Executio
             step,
             ctx.verbose,
             &mut job_env,
+            &mut job_user_env,
             ctx.services.secret_masker,
         ) {
             job_success = false;
@@ -2025,6 +2052,7 @@ async fn execute_job(ctx: JobExecutionContext<'_>) -> Result<JobResult, Executio
         &loop_state.step_outputs_map,
         &loop_state.step_status_map,
         &job_env,
+        &job_user_env,
         &loop_state.job_status_str,
         &current_dir,
     );
@@ -2053,6 +2081,8 @@ struct MatrixExecutionContext<'a> {
     workflow: &'a WorkflowDefinition,
     runtime: &'a dyn ContainerRuntime,
     env_context: &'a HashMap<String, String>,
+    /// Workflow-level user-declared env, threaded in from `JobExecutionContext`.
+    user_env: &'a HashMap<String, String>,
     verbose: bool,
     services: JobServices<'a>,
 }
@@ -2093,6 +2123,7 @@ async fn execute_matrix_combinations(
                 ctx.workflow,
                 ctx.runtime,
                 ctx.env_context,
+                ctx.user_env,
                 ctx.verbose,
                 &ctx.services,
             )
@@ -2134,6 +2165,7 @@ async fn execute_matrix_job(
     workflow: &WorkflowDefinition,
     runtime: &dyn ContainerRuntime,
     base_env_context: &HashMap<String, String>,
+    base_user_env: &HashMap<String, String>,
     verbose: bool,
     services: &JobServices<'_>,
 ) -> Result<JobResult, ExecutionError> {
@@ -2142,15 +2174,22 @@ async fn execute_matrix_job(
 
     wrkflw_logging::info(&format!("Executing matrix job: {}", matrix_job_name));
 
-    // Clone the environment and add matrix-specific values
+    // Clone the environment and add matrix-specific values.
+    // `job_env` is the full lookup map; `job_user_env` mirrors the user slice.
+    // Matrix-derived `MATRIX_*` vars and `MATRIX_CONTEXT` are runner-internal —
+    // they belong in job_env only, not user_env (they surface via `toJSON(matrix)`).
     let mut job_env = base_env_context.clone();
+    let mut job_user_env = base_user_env.clone();
     environment::add_matrix_context(&mut job_env, combination);
 
-    // Add container-level environment variables (lowest precedence)
+    // Add container-level environment variables (lowest precedence). User-declared.
     if let Some(ref container) = job_template.container {
         warn_unsupported_container_fields(container);
         for (key, value) in &container.env {
-            job_env.entry(key.clone()).or_insert_with(|| value.clone());
+            if !job_env.contains_key(key) {
+                job_env.insert(key.clone(), value.clone());
+                job_user_env.insert(key.clone(), value.clone());
+            }
         }
     }
 
@@ -2160,13 +2199,6 @@ async fn execute_matrix_job(
     // We collect resolved values first to avoid borrowing job_env while mutating it.
     {
         let matrix_opt = Some(combination.values.clone());
-        // Bridge: derive user_env from the current job_env via the legacy heuristic.
-        // Commit 2 replaces this with an authoritatively-tracked job_user_env.
-        let user_env: HashMap<String, String> = job_env
-            .iter()
-            .filter(|(k, _)| crate::expression::is_user_env_var(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
         let env_expr_ctx = crate::expression::ExpressionContext {
             env_context: &job_env,
             step_outputs: &HashMap::new(),
@@ -2176,7 +2208,7 @@ async fn execute_matrix_job(
             secrets_context: services.secrets_context,
             needs_context: services.needs_context,
             needs_results: services.needs_results,
-            user_env: &user_env,
+            user_env: &job_user_env,
         };
         let cwd = std::env::current_dir().map_err(|e| {
             ExecutionError::Execution(format!("Failed to get current directory: {}", e))
@@ -2192,7 +2224,8 @@ async fn execute_matrix_job(
             })
             .collect();
         for (key, value) in resolved_env {
-            job_env.insert(key, value);
+            job_env.insert(key.clone(), value.clone());
+            job_user_env.insert(key, value);
         }
     }
 
@@ -2234,6 +2267,7 @@ async fn execute_matrix_job(
                         step,
                         step_idx: idx,
                         job_env: &job_env,
+                        job_user_env: &job_user_env,
                         working_dir: job_dir.path(),
                         runtime,
                         workflow,
@@ -2279,6 +2313,7 @@ async fn execute_matrix_job(
                 step,
                 verbose,
                 &mut job_env,
+                &mut job_user_env,
                 services.secret_masker,
             ) {
                 all_steps_ok = false;
@@ -2300,6 +2335,7 @@ async fn execute_matrix_job(
         &loop_state.step_outputs_map,
         &loop_state.step_status_map,
         &job_env,
+        &job_user_env,
         &loop_state.job_status_str,
         &current_dir,
     );
@@ -2421,6 +2457,7 @@ impl StepLoopState {
         step: &workflow::Step,
         verbose: bool,
         job_env: &mut HashMap<String, String>,
+        job_user_env: &mut HashMap<String, String>,
         secret_masker: Option<&SecretMasker>,
     ) -> bool {
         match outcome {
@@ -2465,6 +2502,7 @@ impl StepLoopState {
 
                 crate::github_env_files::apply_step_environment_updates(
                     job_env,
+                    job_user_env,
                     &mut self.step_outputs_map,
                     step.id.as_deref(),
                 );
@@ -2585,8 +2623,7 @@ async fn run_step_with_guards(
 
     // Check step-level if condition
     if let Some(if_cond) = &step.if_condition {
-        let mut user_env_buf = HashMap::new();
-        let cond_ctx = step_exec_ctx.expr_context(&mut user_env_buf);
+        let cond_ctx = step_exec_ctx.expr_context();
         let should_run = evaluate_condition_with_context(if_cond, &cond_ctx);
         if !should_run {
             wrkflw_logging::info(&format!(
@@ -2690,6 +2727,10 @@ struct StepExecutionContext<'a> {
     step: &'a workflow::Step,
     step_idx: usize,
     job_env: &'a HashMap<String, String>,
+    /// Job-level user-declared env (workflow.env ∪ container.env ∪ job.env, plus
+    /// any `$GITHUB_ENV` writes from prior steps). Excludes runner-seeded vars.
+    /// Consumed by `toJSON(env)` via `ExpressionContext::user_env`.
+    job_user_env: &'a HashMap<String, String>,
     working_dir: &'a Path,
     runtime: &'a dyn ContainerRuntime,
     workflow: &'a WorkflowDefinition,
@@ -2709,25 +2750,8 @@ struct StepExecutionContext<'a> {
 }
 
 impl<'a> StepExecutionContext<'a> {
-    /// Build an `ExpressionContext` from this step context. The returned context
-    /// borrows from `user_env_buf`, which the caller owns — this indirection lets
-    /// us return a `ExpressionContext<'b>` whose lifetime is tied to a caller-
-    /// provided buffer rather than `self` (which already borrows `job_env`).
-    ///
-    /// Bridge behavior (Commit 1): `user_env_buf` is populated by filtering
-    /// `job_env` through the legacy `is_user_env_var` heuristic. Commit 2
-    /// replaces this with an authoritatively-tracked `job_user_env` field on
-    /// `StepExecutionContext`.
-    fn expr_context<'b>(
-        &'b self,
-        user_env_buf: &'b mut HashMap<String, String>,
-    ) -> crate::expression::ExpressionContext<'b> {
-        *user_env_buf = self
-            .job_env
-            .iter()
-            .filter(|(k, _)| crate::expression::is_user_env_var(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+    /// Build an `ExpressionContext` from this step context.
+    fn expr_context(&self) -> crate::expression::ExpressionContext<'_> {
         crate::expression::ExpressionContext {
             env_context: self.job_env,
             step_outputs: self.step_outputs,
@@ -2737,26 +2761,21 @@ impl<'a> StepExecutionContext<'a> {
             secrets_context: self.services.secrets_context,
             needs_context: self.services.needs_context,
             needs_results: self.services.needs_results,
-            user_env: user_env_buf,
+            user_env: self.job_user_env,
         }
     }
 
-    /// Build an `ExpressionContext` using a custom env (e.g. partially-built step env).
-    /// `user_env_buf` is filled with the user-declared slice of `env` and borrowed
-    /// by the returned context; callers must keep it alive alongside the context.
+    /// Build an `ExpressionContext` using a custom env + matching user_env
+    /// (e.g. partially-built step env). Both must cover the same merge layer —
+    /// `env` is env_context (runner + user union), `user_env` is the user slice.
     fn expr_context_with_env<'e>(
         &self,
         env: &'e HashMap<String, String>,
-        user_env_buf: &'e mut HashMap<String, String>,
+        user_env: &'e HashMap<String, String>,
     ) -> crate::expression::ExpressionContext<'e>
     where
         'a: 'e,
     {
-        *user_env_buf = env
-            .iter()
-            .filter(|(k, _)| crate::expression::is_user_env_var(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
         crate::expression::ExpressionContext {
             env_context: env,
             step_outputs: self.step_outputs,
@@ -2766,7 +2785,7 @@ impl<'a> StepExecutionContext<'a> {
             secrets_context: self.services.secrets_context,
             needs_context: self.services.needs_context,
             needs_results: self.services.needs_results,
-            user_env: user_env_buf,
+            user_env,
         }
     }
 }
@@ -2776,8 +2795,7 @@ impl<'a> StepExecutionContext<'a> {
 /// On expression error, returns empty string (matching GitHub Actions behavior
 /// where unresolvable expressions resolve to empty).
 fn preprocess_with_value(value: &str, ctx: &StepExecutionContext<'_>) -> String {
-    let mut user_env_buf = HashMap::new();
-    let expr_ctx = ctx.expr_context(&mut user_env_buf);
+    let expr_ctx = ctx.expr_context();
     crate::substitution::preprocess_expressions(value, ctx.working_dir, &expr_ctx)
         .unwrap_or_default()
 }
@@ -3064,8 +3082,11 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
         wrkflw_logging::info(&format!("  Executing step: {}", step_name));
     }
 
-    // Prepare step environment
+    // Prepare step environment. `step_env` is the merged lookup map (runner +
+    // user); `step_user_env` mirrors only the user-declared slice and is what
+    // `toJSON(env)` sees.
     let mut step_env = ctx.job_env.clone();
+    let mut step_user_env = ctx.job_user_env.clone();
 
     // Add step-level environment variables (with secret + expression substitution)
     for (key, value) in &ctx.step.env {
@@ -3085,8 +3106,7 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
             value.clone()
         };
         // Resolve ${{ }} expressions in env values (e.g. ${{inputs.toolchain}})
-        let mut user_env_buf = HashMap::new();
-        let env_expr_ctx = ctx.expr_context_with_env(&step_env, &mut user_env_buf);
+        let env_expr_ctx = ctx.expr_context_with_env(&step_env, &step_user_env);
         let resolved_value = match crate::substitution::preprocess_expressions(
             &resolved_value,
             ctx.working_dir,
@@ -3095,7 +3115,8 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
             Ok(r) => r,
             Err(_) => resolved_value,
         };
-        step_env.insert(key.clone(), resolved_value);
+        step_env.insert(key.clone(), resolved_value.clone());
+        step_user_env.insert(key.clone(), resolved_value);
     }
 
     // Execute the step based on its type
@@ -3164,6 +3185,7 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
                             ctx.step,
                             action_path,
                             &step_env,
+                            &step_user_env,
                             ctx.working_dir,
                             ctx.runtime,
                             ctx.runner_image,
@@ -3219,6 +3241,7 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
                             ctx.step,
                             &action_dir,
                             &step_env,
+                            &step_user_env,
                             ctx.working_dir,
                             ctx.runtime,
                             ctx.runner_image,
@@ -3648,8 +3671,7 @@ async fn execute_step(ctx: StepExecutionContext<'_>) -> Result<StepResult, Execu
         };
 
         // Resolve expression substitutions (hashFiles, step outputs, env, matrix vars)
-        let mut user_env_buf = HashMap::new();
-        let run_expr_ctx = ctx.expr_context(&mut user_env_buf);
+        let run_expr_ctx = ctx.expr_context();
         let resolved_run = match crate::substitution::preprocess_expressions(
             &resolved_run,
             ctx.working_dir,
@@ -4412,12 +4434,18 @@ async fn run_called_workflow(
     let mut any_failed = false;
     let mut reusable_job_outputs: HashMap<String, HashMap<String, String>> = HashMap::new();
     let mut reusable_job_results: HashMap<String, String> = HashMap::new();
+    // Reusable workflows have their own scope — parent workflow.env doesn't
+    // flow in, and the called workflow's own workflow.env isn't currently
+    // being merged into child_env (pre-existing gap). Pass an empty user_env
+    // for now; job-level env merges still populate it correctly downstream.
+    let child_user_env: HashMap<String, String> = HashMap::new();
     for batch in plan {
         let results = execute_job_batch(
             &batch,
             called,
             ctx.runtime,
             &child_env,
+            &child_user_env,
             ctx.verbose,
             ctx.services.secret_manager,
             ctx.services.secret_masker,
@@ -4562,6 +4590,7 @@ async fn execute_composite_action(
     step: &workflow::Step,
     action_path: &Path,
     job_env: &HashMap<String, String>,
+    job_user_env: &HashMap<String, String>,
     working_dir: &Path,
     runtime: &dyn ContainerRuntime,
     runner_image: &str,
@@ -4604,8 +4633,12 @@ async fn execute_composite_action(
                 }
             };
 
-            // Process inputs from the calling step's 'with' parameters
+            // Process inputs from the calling step's 'with' parameters.
+            // `action_env` is the full lookup map; `action_user_env` mirrors
+            // the user-declared slice. INPUT_* vars are runner-internal — they
+            // go into action_env only, not action_user_env.
             let mut action_env = job_env.clone();
+            let mut action_user_env = job_user_env.clone();
             if let Some(inputs_def) = action_def.get("inputs") {
                 if let Some(inputs_map) = inputs_def.as_mapping() {
                     for (input_name, input_def) in inputs_map {
@@ -4658,6 +4691,7 @@ async fn execute_composite_action(
                     step: &composite_step,
                     step_idx: idx,
                     job_env: &action_env,
+                    job_user_env: &action_user_env,
                     working_dir,
                     runtime,
                     workflow: &workflow::WorkflowDefinition {
@@ -4711,9 +4745,12 @@ async fn execute_composite_action(
 
                 // Read back GITHUB_OUTPUT/GITHUB_ENV/GITHUB_PATH so subsequent
                 // composite steps can reference ${{ steps.<id>.outputs.<key> }}
-                // and see environment changes from prior steps.
+                // and see environment changes from prior steps. $GITHUB_ENV
+                // writes mirror into action_user_env so composite toJSON(env)
+                // sees them.
                 crate::github_env_files::apply_step_environment_updates(
                     &mut action_env,
+                    &mut action_user_env,
                     &mut composite_step_outputs,
                     composite_step.id.as_deref(),
                 );
@@ -4725,6 +4762,7 @@ async fn execute_composite_action(
                         &action_def,
                         &composite_step_outputs,
                         &action_env,
+                        &action_user_env,
                         job_env,
                         working_dir,
                         &composite_job_status,
@@ -4744,6 +4782,7 @@ async fn execute_composite_action(
                 &action_def,
                 &composite_step_outputs,
                 &action_env,
+                &action_user_env,
                 job_env,
                 working_dir,
                 &composite_job_status,
@@ -4807,6 +4846,7 @@ fn propagate_composite_outputs(
     action_def: &serde_yaml::Value,
     composite_step_outputs: &HashMap<String, HashMap<String, String>>,
     action_env: &HashMap<String, String>,
+    action_user_env: &HashMap<String, String>,
     caller_job_env: &HashMap<String, String>,
     working_dir: &Path,
     job_status: &str,
@@ -4822,12 +4862,6 @@ fn propagate_composite_outputs(
     let empty_secrets = HashMap::new();
     let empty_needs = HashMap::new();
     let empty_results = HashMap::new();
-    // Bridge: derive user_env from action_env via the legacy heuristic.
-    let user_env: HashMap<String, String> = action_env
-        .iter()
-        .filter(|(k, _)| crate::expression::is_user_env_var(k))
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
     let expr_ctx = crate::expression::ExpressionContext {
         env_context: action_env,
         step_outputs: composite_step_outputs,
@@ -4837,7 +4871,7 @@ fn propagate_composite_outputs(
         secrets_context: &empty_secrets,
         needs_context: &empty_needs,
         needs_results: &empty_results,
-        user_env: &user_env,
+        user_env: action_user_env,
     };
 
     // Collect evaluated outputs
@@ -5019,14 +5053,9 @@ fn convert_yaml_to_step(step_yaml: &serde_yaml::Value) -> Result<workflow::Step,
 fn evaluate_job_condition(
     condition: &str,
     env_context: &HashMap<String, String>,
+    user_env: &HashMap<String, String>,
     _workflow: &WorkflowDefinition,
 ) -> bool {
-    // Bridge: derive user_env from env_context via the legacy heuristic.
-    let user_env: HashMap<String, String> = env_context
-        .iter()
-        .filter(|(k, _)| crate::expression::is_user_env_var(k))
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
     let ctx = crate::expression::ExpressionContext {
         env_context,
         step_outputs: &HashMap::new(),
@@ -5036,7 +5065,7 @@ fn evaluate_job_condition(
         secrets_context: &HashMap::new(),
         needs_context: &HashMap::new(),
         needs_results: &HashMap::new(),
-        user_env: &user_env,
+        user_env,
     };
     evaluate_condition_with_context(condition, &ctx)
 }
@@ -5104,17 +5133,12 @@ fn resolve_job_outputs(
     step_outputs_map: &HashMap<String, HashMap<String, String>>,
     step_status_map: &HashMap<String, (String, String)>,
     env_context: &HashMap<String, String>,
+    user_env: &HashMap<String, String>,
     job_status: &str,
     working_dir: &Path,
 ) -> HashMap<String, String> {
     let mut resolved = HashMap::new();
     if let Some(outputs) = &job.outputs {
-        // Bridge: derive user_env from env_context via the legacy heuristic.
-        let user_env: HashMap<String, String> = env_context
-            .iter()
-            .filter(|(k, _)| crate::expression::is_user_env_var(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
         let ctx = crate::expression::ExpressionContext {
             env_context,
             step_outputs: step_outputs_map,
@@ -5124,7 +5148,7 @@ fn resolve_job_outputs(
             secrets_context: &HashMap::new(),
             needs_context: &HashMap::new(),
             needs_results: &HashMap::new(),
-            user_env: &user_env,
+            user_env,
         };
         for (key, expr) in outputs {
             match crate::substitution::preprocess_expressions(expr, working_dir, &ctx) {
@@ -5702,8 +5726,8 @@ mod tests {
     fn condition_true_false_literals() {
         let env = HashMap::new();
         let wf = empty_workflow();
-        assert!(evaluate_job_condition("true", &env, &wf));
-        assert!(!evaluate_job_condition("false", &env, &wf));
+        assert!(evaluate_job_condition("true", &env, &env, &wf));
+        assert!(!evaluate_job_condition("false", &env, &env, &wf));
     }
 
     #[test]
@@ -5715,10 +5739,12 @@ mod tests {
         assert!(!evaluate_job_condition(
             "steps.build.outcome == 'success'",
             &env,
+            &env,
             &wf
         ));
         assert!(!evaluate_job_condition(
             "steps.build.outcome == 'failure'",
+            &env,
             &env,
             &wf
         ));
@@ -5728,28 +5754,28 @@ mod tests {
     fn condition_success_function_defaults_true() {
         let env = HashMap::new();
         let wf = empty_workflow();
-        assert!(evaluate_job_condition("success()", &env, &wf));
+        assert!(evaluate_job_condition("success()", &env, &env, &wf));
     }
 
     #[test]
     fn condition_failure_function_defaults_false() {
         let env = HashMap::new();
         let wf = empty_workflow();
-        assert!(!evaluate_job_condition("failure()", &env, &wf));
+        assert!(!evaluate_job_condition("failure()", &env, &env, &wf));
     }
 
     #[test]
     fn condition_always_function_defaults_true() {
         let env = HashMap::new();
         let wf = empty_workflow();
-        assert!(evaluate_job_condition("always()", &env, &wf));
+        assert!(evaluate_job_condition("always()", &env, &env, &wf));
     }
 
     #[test]
     fn condition_cancelled_function_defaults_false() {
         let env = HashMap::new();
         let wf = empty_workflow();
-        assert!(!evaluate_job_condition("cancelled()", &env, &wf));
+        assert!(!evaluate_job_condition("cancelled()", &env, &env, &wf));
     }
 
     #[test]
@@ -5757,7 +5783,12 @@ mod tests {
         let env = HashMap::new();
         let wf = empty_workflow();
         // success() is present, so compound expression should default to true
-        assert!(evaluate_job_condition("failure() || success()", &env, &wf));
+        assert!(evaluate_job_condition(
+            "failure() || success()",
+            &env,
+            &env,
+            &wf
+        ));
     }
 
     #[test]
@@ -5767,6 +5798,7 @@ mod tests {
         // Only negative functions, no positive counterpart → false
         assert!(!evaluate_job_condition(
             "failure() || cancelled()",
+            &env,
             &env,
             &wf
         ));
@@ -5778,11 +5810,21 @@ mod tests {
         let wf = empty_workflow();
         // always() → true, failure() → false, true && false → false
         // The expression evaluator correctly evaluates the compound expression
-        assert!(!evaluate_job_condition("always() && failure()", &env, &wf));
+        assert!(!evaluate_job_condition(
+            "always() && failure()",
+            &env,
+            &env,
+            &wf
+        ));
         // always() alone → true
-        assert!(evaluate_job_condition("always()", &env, &wf));
+        assert!(evaluate_job_condition("always()", &env, &env, &wf));
         // always() || failure() → true (|| returns first truthy)
-        assert!(evaluate_job_condition("always() || failure()", &env, &wf));
+        assert!(evaluate_job_condition(
+            "always() || failure()",
+            &env,
+            &env,
+            &wf
+        ));
     }
 
     #[test]
@@ -5791,9 +5833,14 @@ mod tests {
         let wf = empty_workflow();
         // Malformed conditions should evaluate to false (not true) — matching
         // GitHub Actions behavior where unparseable expressions error out.
-        assert!(!evaluate_job_condition("&&& invalid syntax", &env, &wf));
-        assert!(!evaluate_job_condition("== broken", &env, &wf));
-        assert!(!evaluate_job_condition("((( unmatched", &env, &wf));
+        assert!(!evaluate_job_condition(
+            "&&& invalid syntax",
+            &env,
+            &env,
+            &wf
+        ));
+        assert!(!evaluate_job_condition("== broken", &env, &env, &wf));
+        assert!(!evaluate_job_condition("((( unmatched", &env, &env, &wf));
     }
 
     #[test]
@@ -5806,15 +5853,22 @@ mod tests {
         assert!(evaluate_job_condition(
             "env.MY_STEPS_COUNT == '5'",
             &env,
+            &env,
             &wf
         ));
         assert!(evaluate_job_condition(
             "env._STEPS_CHECK == 'ok'",
             &env,
+            &env,
             &wf
         ));
         // Missing env var → null, null != '5' → false
-        assert!(!evaluate_job_condition("env.MISSING_VAR == '5'", &env, &wf));
+        assert!(!evaluate_job_condition(
+            "env.MISSING_VAR == '5'",
+            &env,
+            &env,
+            &wf
+        ));
     }
 
     // --- volume path traversal tests ---
@@ -6272,6 +6326,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -6323,6 +6378,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -6379,6 +6435,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -6428,6 +6485,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -6478,6 +6536,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -6527,6 +6586,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -6574,6 +6634,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7113,6 +7174,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7160,6 +7222,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7203,6 +7266,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7238,6 +7302,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7275,6 +7340,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7323,6 +7389,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7369,6 +7436,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7415,6 +7483,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7459,6 +7528,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: &working_dir,
             runtime: &runtime,
             workflow: &workflow,
@@ -7684,6 +7754,7 @@ runs:
             &step_outputs,
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
             "success",
             Path::new("."),
         );
@@ -7704,6 +7775,7 @@ runs:
 
         let result = resolve_job_outputs(
             &job,
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
@@ -7792,6 +7864,7 @@ runs:
             &step_outputs,
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
             "success",
             Path::new("."),
         );
@@ -7806,6 +7879,7 @@ runs:
 
         let resolved = resolve_job_outputs(
             &job,
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
@@ -7830,6 +7904,7 @@ runs:
 
         let resolved = resolve_job_outputs(
             &job,
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
@@ -7874,6 +7949,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -7920,6 +7996,7 @@ runs:
             step: &dl_step,
             step_idx: 1,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: dl_workspace.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -7995,6 +8072,7 @@ runs:
             step: &run_step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8040,6 +8118,7 @@ runs:
             step: &up_step,
             step_idx: 1,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8091,6 +8170,7 @@ runs:
             step: &dl_step,
             step_idx: 2,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: dl_workspace.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8159,6 +8239,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8365,6 +8446,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8435,6 +8517,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: dl_workspace.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8490,6 +8573,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8542,6 +8626,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8600,6 +8685,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8744,6 +8830,7 @@ runs:
             step: &step,
             step_idx: 0,
             job_env: &job_env,
+            job_user_env: &job_env,
             working_dir: working_dir.path(),
             runtime: &runtime,
             workflow: &workflow,
@@ -8837,6 +8924,7 @@ runs:
             &action_def,
             &composite_step_outputs,
             &action_env,
+            &action_env,
             &caller_env,
             &working_dir,
             "success",
@@ -8875,6 +8963,7 @@ runs:
         propagate_composite_outputs(
             &action_def,
             &composite_step_outputs,
+            &action_env,
             &action_env,
             &caller_env,
             &working_dir,
@@ -8921,6 +9010,7 @@ runs:
         propagate_composite_outputs(
             &action_def,
             &composite_step_outputs,
+            &action_env,
             &action_env,
             &caller_env,
             &working_dir,
@@ -8971,6 +9061,7 @@ runs:
         propagate_composite_outputs(
             &action_def,
             &composite_step_outputs,
+            &action_env,
             &action_env,
             &caller_env,
             &working_dir,
@@ -9024,6 +9115,7 @@ runs:
         propagate_composite_outputs(
             &action_def,
             &composite_step_outputs,
+            &action_env,
             &action_env,
             &caller_env,
             &working_dir,
@@ -9097,6 +9189,7 @@ runs:
         propagate_composite_outputs(
             &action_def,
             &composite_step_outputs,
+            &action_env,
             &action_env,
             &caller_env,
             &working_dir,

--- a/crates/executor/src/environment.rs
+++ b/crates/executor/src/environment.rs
@@ -429,31 +429,4 @@ mod tests {
     fn extract_repo_from_invalid_url() {
         assert_eq!(extract_repo_from_url("not-a-url"), None);
     }
-
-    #[test]
-    fn is_user_env_var_filters_all_github_context_keys() {
-        use crate::expression::is_user_env_var;
-
-        let workflow_yaml = r#"
-name: test
-on: push
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo hi
-"#;
-        let workflow: wrkflw_parser::workflow::WorkflowDefinition =
-            serde_yaml::from_str(workflow_yaml).expect("valid workflow yaml");
-        let tmp = std::env::temp_dir().join("wrkflw_env_test");
-        let _ = std::fs::create_dir_all(&tmp);
-        let ctx = create_github_context(&workflow, &tmp);
-        for key in ctx.keys() {
-            assert!(
-                !is_user_env_var(key),
-                "internal key '{}' should be filtered by is_user_env_var but was not",
-                key
-            );
-        }
-    }
 }

--- a/crates/executor/src/expression.rs
+++ b/crates/executor/src/expression.rs
@@ -350,6 +350,14 @@ pub struct ExpressionContext<'a> {
     pub needs_context: &'a HashMap<String, HashMap<String, String>>,
     /// Job results from upstream jobs: `job_name -> "success" | "failure" | "skipped"`.
     pub needs_results: &'a HashMap<String, String>,
+    /// User-declared env vars only (merged workflow/job/step `env:` plus step-authored
+    /// `$GITHUB_ENV` writes). `env_context` holds the union of these and runner-seeded
+    /// vars; `user_env` is the user's slice, consumed by `toJSON(env)` / bare `env`.
+    ///
+    /// Invariant: every key inserted here must have been declared by the user (YAML
+    /// `env:` at any scope, or written to `$GITHUB_ENV` by a step). Runner-seeded
+    /// vars (GITHUB_*, RUNNER_*, INPUT_*, WRKFLW_*, CI, MATRIX_*) must NOT be inserted.
+    pub user_env: &'a HashMap<String, String>,
 }
 
 impl<'a> ExpressionContext<'a> {
@@ -488,10 +496,13 @@ impl<'a> ExpressionContext<'a> {
                 ExprValue::Object(map)
             }
             "env" if parts.len() == 1 => {
+                // Dump only user-declared env vars. `env_context` holds the union
+                // (user + runner-seeded); `user_env` is the user's slice tracked
+                // separately from the construction site downward. See the
+                // `user_env` field doc on `ExpressionContext`.
                 let map = self
-                    .env_context
+                    .user_env
                     .iter()
-                    .filter(|(k, _)| is_user_env_var(k))
                     .map(|(k, v)| (k.clone(), ExprValue::String(v.clone())))
                     .collect();
                 ExprValue::Object(map)
@@ -1065,6 +1076,7 @@ mod tests {
 
     lazy_static::lazy_static! {
         static ref EMPTY_ENV: HashMap<String, String> = HashMap::new();
+        static ref EMPTY_USER_ENV: HashMap<String, String> = HashMap::new();
         static ref EMPTY_STEPS: HashMap<String, HashMap<String, String>> = HashMap::new();
         static ref EMPTY_MATRIX: Option<HashMap<String, Value>> = None;
         static ref EMPTY_STATUSES: HashMap<String, (String, String)> = HashMap::new();
@@ -1083,11 +1095,17 @@ mod tests {
             secrets_context: &EMPTY_SECRETS,
             needs_context: &EMPTY_NEEDS,
             needs_results: &EMPTY_NEEDS_RESULTS,
+            user_env: &EMPTY_USER_ENV,
         }
     }
 
     /// Build an `ExpressionContext` from the fields that vary across tests;
-    /// all other fields default to empty/success.
+    /// all other fields default to empty/success. The `env` map is wired into
+    /// both `env_context` (for dotted `env.X` lookups) AND `user_env` (for
+    /// `toJSON(env)` / bare `env`), so tests that don't distinguish the two
+    /// populations continue to work with a single input map. Tests that need
+    /// to distinguish user-declared from runner-seeded env should construct
+    /// `ExpressionContext` directly.
     fn make_ctx<'a>(
         env: &'a HashMap<String, String>,
         steps: &'a HashMap<String, HashMap<String, String>>,
@@ -1102,6 +1120,7 @@ mod tests {
             secrets_context: &EMPTY_SECRETS,
             needs_context: &EMPTY_NEEDS,
             needs_results: &EMPTY_NEEDS_RESULTS,
+            user_env: env,
         }
     }
 
@@ -1605,15 +1624,27 @@ mod tests {
 
     #[test]
     fn tojson_env_returns_object() {
-        let mut env = HashMap::new();
-        env.insert("MY_VAR".to_string(), "hello".to_string());
-        env.insert("OTHER".to_string(), "world".to_string());
-        // System vars should be excluded from the env object
-        env.insert("GITHUB_SHA".to_string(), "abc123".to_string());
-        env.insert("RUNNER_OS".to_string(), "Linux".to_string());
-        env.insert("INPUT_NAME".to_string(), "test".to_string());
-        env.insert("CI".to_string(), "true".to_string());
-        let ctx = make_ctx(&env, &EMPTY_STEPS, &EMPTY_MATRIX);
+        // env_context holds the union of user + runner env; user_env holds only
+        // what the user declared. toJSON(env) dumps user_env.
+        let mut user_env = HashMap::new();
+        user_env.insert("MY_VAR".to_string(), "hello".to_string());
+        user_env.insert("OTHER".to_string(), "world".to_string());
+        let mut env_context = user_env.clone();
+        env_context.insert("GITHUB_SHA".to_string(), "abc123".to_string());
+        env_context.insert("RUNNER_OS".to_string(), "Linux".to_string());
+        env_context.insert("INPUT_NAME".to_string(), "test".to_string());
+        env_context.insert("CI".to_string(), "true".to_string());
+        let ctx = ExpressionContext {
+            env_context: &env_context,
+            user_env: &user_env,
+            step_outputs: &EMPTY_STEPS,
+            matrix_combination: &EMPTY_MATRIX,
+            step_statuses: &EMPTY_STATUSES,
+            job_status: "success",
+            secrets_context: &EMPTY_SECRETS,
+            needs_context: &EMPTY_NEEDS,
+            needs_results: &EMPTY_NEEDS_RESULTS,
+        };
         let result = evaluate("toJSON(env)", &ctx).unwrap();
         let s = result.to_output_string();
         let parsed: serde_json::Value = serde_json::from_str(&s).expect("should be valid JSON");
@@ -1622,17 +1653,20 @@ mod tests {
         assert_eq!(obj.get("OTHER").unwrap(), "world");
         assert!(
             obj.get("GITHUB_SHA").is_none(),
-            "should exclude GITHUB_ vars"
+            "runner-seeded GITHUB_SHA should not leak into toJSON(env)"
         );
         assert!(
             obj.get("RUNNER_OS").is_none(),
-            "should exclude RUNNER_ vars"
+            "runner-seeded RUNNER_OS should not leak into toJSON(env)"
         );
         assert!(
             obj.get("INPUT_NAME").is_none(),
-            "should exclude INPUT_ vars"
+            "runner-seeded INPUT_NAME should not leak into toJSON(env)"
         );
-        assert!(obj.get("CI").is_none(), "should exclude CI");
+        assert!(
+            obj.get("CI").is_none(),
+            "runner-seeded CI should not leak into toJSON(env)"
+        );
     }
 
     #[test]
@@ -1677,40 +1711,94 @@ mod tests {
 
     #[test]
     fn tojson_env_empty_when_only_internal_vars() {
-        let mut env = HashMap::new();
-        env.insert("GITHUB_SHA".to_string(), "abc123".to_string());
-        env.insert("RUNNER_OS".to_string(), "Linux".to_string());
-        env.insert("CI".to_string(), "true".to_string());
-        let ctx = make_ctx(&env, &EMPTY_STEPS, &EMPTY_MATRIX);
+        // env_context has runner-seeded vars; user_env is empty (user declared nothing).
+        let mut env_context = HashMap::new();
+        env_context.insert("GITHUB_SHA".to_string(), "abc123".to_string());
+        env_context.insert("RUNNER_OS".to_string(), "Linux".to_string());
+        env_context.insert("CI".to_string(), "true".to_string());
+        let ctx = ExpressionContext {
+            env_context: &env_context,
+            user_env: &EMPTY_USER_ENV,
+            step_outputs: &EMPTY_STEPS,
+            matrix_combination: &EMPTY_MATRIX,
+            step_statuses: &EMPTY_STATUSES,
+            job_status: "success",
+            secrets_context: &EMPTY_SECRETS,
+            needs_context: &EMPTY_NEEDS,
+            needs_results: &EMPTY_NEEDS_RESULTS,
+        };
         let result = evaluate("toJSON(env)", &ctx).unwrap();
         let s = result.to_output_string();
         let parsed: serde_json::Value = serde_json::from_str(&s).expect("should be valid JSON");
         let obj = parsed.as_object().expect("should be a JSON object");
         assert!(
             obj.is_empty(),
-            "should be empty when all vars are internal: {}",
+            "should be empty when no user env is declared: {}",
             s
         );
     }
 
     #[test]
-    fn tojson_env_excludes_user_var_with_internal_prefix() {
-        // KNOWN LIMITATION: user-defined vars that happen to match internal
-        // prefixes (GITHUB_*, RUNNER_*, etc.) are incorrectly filtered out.
-        let mut env = HashMap::new();
-        env.insert("GITHUB_CUSTOM".to_string(), "user-val".to_string());
-        env.insert("MY_VAR".to_string(), "hello".to_string());
-        let ctx = make_ctx(&env, &EMPTY_STEPS, &EMPTY_MATRIX);
+    fn tojson_env_includes_user_var_with_internal_prefix() {
+        // A user-declared `GITHUB_CUSTOM` (e.g. from `env: { GITHUB_CUSTOM: ... }`
+        // in YAML) must appear in toJSON(env) — it's in user_env regardless of
+        // what prefix the key happens to have. This is the bug the refactor fixes.
+        let mut user_env = HashMap::new();
+        user_env.insert("GITHUB_CUSTOM".to_string(), "user-val".to_string());
+        user_env.insert("MY_VAR".to_string(), "hello".to_string());
+        // env_context mirrors user_env for lookup coherence.
+        let env_context = user_env.clone();
+        let ctx = ExpressionContext {
+            env_context: &env_context,
+            user_env: &user_env,
+            step_outputs: &EMPTY_STEPS,
+            matrix_combination: &EMPTY_MATRIX,
+            step_statuses: &EMPTY_STATUSES,
+            job_status: "success",
+            secrets_context: &EMPTY_SECRETS,
+            needs_context: &EMPTY_NEEDS,
+            needs_results: &EMPTY_NEEDS_RESULTS,
+        };
         let result = evaluate("toJSON(env)", &ctx).unwrap();
         let s = result.to_output_string();
         let parsed: serde_json::Value = serde_json::from_str(&s).expect("should be valid JSON");
         let obj = parsed.as_object().expect("should be a JSON object");
         assert_eq!(obj.get("MY_VAR").unwrap(), "hello");
-        // GITHUB_CUSTOM is excluded despite being user-defined — this is the
-        // known limitation of the heuristic prefix filter.
+        assert_eq!(
+            obj.get("GITHUB_CUSTOM").unwrap(),
+            "user-val",
+            "user-declared var with GITHUB_ prefix must appear in toJSON(env)"
+        );
+    }
+
+    #[test]
+    fn tojson_env_includes_user_declared_github_token() {
+        // The canonical real-world case: `env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }`.
+        // The token is user-declared and must appear in toJSON(env).
+        let mut user_env = HashMap::new();
+        user_env.insert("GITHUB_TOKEN".to_string(), "ghp_user_supplied".to_string());
+        let mut env_context = user_env.clone();
+        // Runner-seeded vars coexist in env_context but must not leak into toJSON(env).
+        env_context.insert("GITHUB_SHA".to_string(), "abc123".to_string());
+        let ctx = ExpressionContext {
+            env_context: &env_context,
+            user_env: &user_env,
+            step_outputs: &EMPTY_STEPS,
+            matrix_combination: &EMPTY_MATRIX,
+            step_statuses: &EMPTY_STATUSES,
+            job_status: "success",
+            secrets_context: &EMPTY_SECRETS,
+            needs_context: &EMPTY_NEEDS,
+            needs_results: &EMPTY_NEEDS_RESULTS,
+        };
+        let result = evaluate("toJSON(env)", &ctx).unwrap();
+        let s = result.to_output_string();
+        let parsed: serde_json::Value = serde_json::from_str(&s).expect("should be valid JSON");
+        let obj = parsed.as_object().expect("should be a JSON object");
+        assert_eq!(obj.get("GITHUB_TOKEN").unwrap(), "ghp_user_supplied");
         assert!(
-            obj.get("GITHUB_CUSTOM").is_none(),
-            "user var with GITHUB_ prefix is incorrectly excluded (known limitation)"
+            obj.get("GITHUB_SHA").is_none(),
+            "process-inherited GITHUB_SHA must not appear in toJSON(env)"
         );
     }
 
@@ -2008,6 +2096,7 @@ mod tests {
     ) -> ExpressionContext<'a> {
         ExpressionContext {
             env_context: &EMPTY_ENV,
+            user_env: &EMPTY_USER_ENV,
             step_outputs,
             matrix_combination: &EMPTY_MATRIX,
             step_statuses,
@@ -2191,6 +2280,7 @@ mod tests {
     ) -> ExpressionContext<'a> {
         ExpressionContext {
             env_context: &EMPTY_ENV,
+            user_env: &EMPTY_USER_ENV,
             step_outputs: &EMPTY_STEPS,
             matrix_combination: &EMPTY_MATRIX,
             step_statuses: &EMPTY_STATUSES,
@@ -2339,6 +2429,7 @@ mod tests {
     fn make_secrets_ctx(secrets: &HashMap<String, String>) -> ExpressionContext<'_> {
         ExpressionContext {
             env_context: &EMPTY_ENV,
+            user_env: &EMPTY_USER_ENV,
             step_outputs: &EMPTY_STEPS,
             matrix_combination: &EMPTY_MATRIX,
             step_statuses: &EMPTY_STATUSES,

--- a/crates/executor/src/expression.rs
+++ b/crates/executor/src/expression.rs
@@ -278,27 +278,6 @@ impl<'a> Tokenizer<'a> {
     }
 }
 
-/// Returns `true` if this env-var key belongs to the user-defined `env:` context
-/// rather than an internal variable injected by the executor/runner.
-///
-/// KNOWN LIMITATION: Because `env_context` is a single flat HashMap that mixes
-/// user-declared env vars with runner-injected ones, we use a heuristic prefix
-/// filter. This means a user-defined var like `env: { GITHUB_CUSTOM: "val" }`
-/// or the commonly used `env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }`
-/// will be incorrectly excluded from `toJSON(env)` output. The proper fix is to
-/// separate user env from runner env upstream in ExpressionContext, but that is
-/// a larger refactor tracked separately.
-///
-/// Update this function when new internal prefixes are introduced.
-pub(crate) fn is_user_env_var(key: &str) -> bool {
-    !key.starts_with("GITHUB_")
-        && !key.starts_with("RUNNER_")
-        && !key.starts_with("INPUT_")
-        && !key.starts_with("WRKFLW_")
-        && key != "CI"
-        && key != "MATRIX_CONTEXT" // inserted by add_matrix_context() in environment.rs
-}
-
 /// If `key` is a `GITHUB_*` env var that belongs on GHA's `github.*` expression
 /// context, returns the stripped + lowercased suffix used as the object key
 /// (`GITHUB_SHA` → `"sha"`). Returns `None` for non-`GITHUB_*` keys, the bare

--- a/crates/executor/src/github_env_files.rs
+++ b/crates/executor/src/github_env_files.rs
@@ -144,6 +144,7 @@ pub fn read_step_environment_updates(job_env: &HashMap<String, String>) -> StepE
 /// - Clears per-step files so the next step starts fresh
 pub fn apply_step_environment_updates(
     job_env: &mut HashMap<String, String>,
+    job_user_env: &mut HashMap<String, String>,
     step_outputs_map: &mut HashMap<String, HashMap<String, String>>,
     step_id: Option<&str>,
 ) {
@@ -154,8 +155,13 @@ pub fn apply_step_environment_updates(
         step_outputs_map.insert(id.to_string(), updates.outputs);
     }
 
-    // Merge GITHUB_ENV entries into job_env for subsequent steps
+    // Merge GITHUB_ENV entries into job_env for subsequent steps.
+    // These are user-declared by definition (the step wrote them via
+    // `echo KEY=VAL >> $GITHUB_ENV`), so mirror into job_user_env too.
+    // GITHUB_PATH updates below modify PATH in job_env only — PATH is not
+    // a user-declared env var and must not leak into toJSON(env).
     for (k, v) in updates.env_vars {
+        job_user_env.insert(k.clone(), v.clone());
         job_env.insert(k, v);
     }
 
@@ -414,8 +420,14 @@ mod tests {
         job_env.insert("PATH".to_string(), "/usr/bin".to_string());
 
         let mut step_outputs_map = HashMap::new();
+        let mut job_user_env = HashMap::new();
 
-        apply_step_environment_updates(&mut job_env, &mut step_outputs_map, Some("build"));
+        apply_step_environment_updates(
+            &mut job_env,
+            &mut job_user_env,
+            &mut step_outputs_map,
+            Some("build"),
+        );
 
         // Step outputs stored under step ID
         assert_eq!(
@@ -428,8 +440,15 @@ mod tests {
         );
         // Env merged
         assert_eq!(job_env.get("CC").unwrap(), "gcc");
+        // $GITHUB_ENV writes must mirror into user_env
+        assert_eq!(job_user_env.get("CC").unwrap(), "gcc");
         // Path prepended
         assert_eq!(job_env.get("PATH").unwrap(), "/opt/gcc/bin:/usr/bin");
+        // PATH updates from $GITHUB_PATH must NOT appear in user_env
+        assert!(
+            !job_user_env.contains_key("PATH"),
+            "PATH should not leak into user_env"
+        );
         // Files cleared for next step
         assert!(fs::read_to_string(github_dir.join("output"))
             .unwrap()
@@ -468,19 +487,30 @@ mod tests {
         job_env.insert("PATH".to_string(), "/usr/bin".to_string());
 
         let mut step_outputs_map = HashMap::new();
+        let mut job_user_env = HashMap::new();
 
         // Step 1 writes /opt/tool to GITHUB_PATH
         fs::write(&output_path, "").unwrap();
         fs::write(&env_path, "").unwrap();
         fs::write(&path_path, "/opt/tool\n").unwrap();
-        apply_step_environment_updates(&mut job_env, &mut step_outputs_map, None);
+        apply_step_environment_updates(
+            &mut job_env,
+            &mut job_user_env,
+            &mut step_outputs_map,
+            None,
+        );
         assert_eq!(job_env.get("PATH").unwrap(), "/opt/tool:/usr/bin");
 
         // Step 2 writes /opt/other to GITHUB_PATH
         fs::write(&output_path, "").unwrap();
         fs::write(&env_path, "").unwrap();
         fs::write(&path_path, "/opt/other\n").unwrap();
-        apply_step_environment_updates(&mut job_env, &mut step_outputs_map, None);
+        apply_step_environment_updates(
+            &mut job_env,
+            &mut job_user_env,
+            &mut step_outputs_map,
+            None,
+        );
 
         // /opt/tool should appear exactly once (not duplicated)
         let path = job_env.get("PATH").unwrap();

--- a/crates/executor/src/substitution.rs
+++ b/crates/executor/src/substitution.rs
@@ -218,6 +218,7 @@ mod tests {
     ) -> ExpressionContext<'a> {
         ExpressionContext {
             env_context: env,
+            user_env: env,
             step_outputs,
             matrix_combination: matrix,
             step_statuses: &EMPTY_STATUSES,


### PR DESCRIPTION
## Summary

Fixes the last rough edge in wrkflw's expression evaluator: `toJSON(env)`. Prior PRs (#97–#101) landed bare-context support for `toJSON(steps)`, `toJSON(needs)`, `toJSON(github)`, `toJSON(secrets)`, and `toJSON(matrix)`. `toJSON(env)` was the outlier — it used an `is_user_env_var()` prefix heuristic that incorrectly excluded user-declared vars with runner-style names (most notably `GITHUB_TOKEN`).

TODO item 6 from the [bare context serialization plan](../.claude/todos/active.md).

## Root cause

`env_context` is a single flat `HashMap<String, String>` that mixes user-declared env with runner-seeded vars (GITHUB_*, RUNNER_*, INPUT_*, WRKFLW_*, CI, MATRIX_*). `toJSON(env)` should dump only the user slice — but no key-level filter can separate the two populations after they've been merged. Users writing the canonical pattern `env: { GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }} }` would silently lose their token from `toJSON(env)` output.

## The fix

Separate the two populations at the source:

- Adds `user_env: &'a HashMap<String, String>` to `ExpressionContext`, read by the `toJSON(env)` / bare-`env` resolve arm.
- `env_context` remains the union used for dotted lookups (`env.FOO`, `github.X`).
- `user_env` is maintained in parallel through every scope where user-declared env enters the system:
  1. **Workflow**: seeded empty, populated from resolved `workflow.env` (with `or_insert` precedence so it can't shadow runner vars).
  2. **Job**: clone workflow user_env, layer `container.env` + `job.env`. Runner-internal `GITHUB_JOB` stays in env_context only.
  3. **Matrix jobs**: same as job-level but skip `MATRIX_*` / `MATRIX_CONTEXT` — those are runner-internal and belong to `toJSON(matrix)`.
  4. **Step**: clone job user_env, layer resolved `step.env`.
  5. **\$GITHUB_ENV writes**: `apply_step_environment_updates` mirrors env-file writes into `user_env`, so a step writing `echo FOO=bar >> \$GITHUB_ENV` sees FOO in the next step's `toJSON(env)`. `\$GITHUB_PATH` updates stay out of `user_env` (PATH is not a user-declared env var).

## Commits

- **f4a8978** — scaffolding: adds the field, threads it through every construction site with a heuristic bridge so the tree stays green. No behavior change.
- **905f029** — replaces bridges with real tracking through the workflow→job→step merges, wires \$GITHUB_ENV writes into user_env, deletes `is_user_env_var()` and its test.

## Scope decisions (flagged in the code)

- **Reusable workflows** (`run_called_workflow`) start with an empty user_env — parent workflow.env doesn't leak across reusable-workflow boundaries, and the called workflow's own workflow.env isn't currently merged into child_env (pre-existing gap, not fixed here). Job-level merges still populate user_env correctly downstream.
- **GitLab pipelines** don't carry workflow-level `env:`, so that path also starts empty.
- **Sibling bug in `toJSON(github)`** — a user-declared `GITHUB_CUSTOM` will still appear in `toJSON(github)` masquerading as a runner var. Deferred to a follow-up; this PR stays focused on `toJSON(env)`.

## Test plan

- [x] `cargo test -p wrkflw-executor --lib` — 398 pass (1 deleted: `is_user_env_var_filters_all_github_context_keys` in environment.rs tested the now-gone heuristic).
- [x] `cargo build --workspace` — clean.
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.

### New / updated tests

- **Added** `tojson_env_includes_user_var_with_internal_prefix` — user-declared `GITHUB_CUSTOM` appears in `toJSON(env)` (inverted from the prior `tojson_env_excludes_user_var_with_internal_prefix`, which asserted the bug as if it were a feature).
- **Added** `tojson_env_includes_user_declared_github_token` — the canonical `GITHUB_TOKEN` case: user-declared token appears; process-inherited `GITHUB_SHA` doesn't.
- **Updated** `tojson_env_returns_object` and `tojson_env_empty_when_only_internal_vars` to construct `ExpressionContext` directly with distinct `env_context` vs `user_env` populations.
- **Updated** `apply_updates_merges_env_and_path` to verify \$GITHUB_ENV writes mirror into user_env and \$GITHUB_PATH writes don't.