### PR TITLE
feat(ui): rebuild TUI to match the new design system

### DIFF
--- a/crates/ui/src/app/mod.rs
+++ b/crates/ui/src/app/mod.rs
@@ -69,7 +69,18 @@ pub async fn run_wrkflw_tui(
                 .to_string_lossy()
                 .into_owned();
 
-            let job_names = crate::utils::extract_job_names(path);
+            let (definition, job_names) = {
+                use std::sync::Arc;
+                use wrkflw_parser::workflow::parse_workflow;
+                match parse_workflow(path) {
+                    Ok(def) => {
+                        let mut names: Vec<String> = def.jobs.keys().cloned().collect();
+                        names.sort();
+                        (Some(Arc::new(def)), names)
+                    }
+                    Err(_) => (None, crate::utils::extract_job_names(path)),
+                }
+            };
 
             app.workflows = vec![Workflow {
                 name: name.clone(),
@@ -79,6 +90,7 @@ pub async fn run_wrkflw_tui(
                 execution_details: None,
                 job_names,
                 trigger_match: None,
+                definition,
             }];
 
             // Queue the single workflow for execution
@@ -248,12 +260,21 @@ fn run_tui_event_loop(
                         }
                     }
                     KeyCode::Tab => {
-                        // Cycle through tabs
-                        app.switch_tab((app.selected_tab + 1) % 4);
+                        // Inside the Step Inspector, Tab cycles inspector
+                        // sub-tabs (Output / Env / Files / Matrix / Timeline);
+                        // elsewhere it cycles top-level tabs.
+                        if app.selected_tab == 1 && app.detailed_view {
+                            app.step_inspector_tab = (app.step_inspector_tab + 1) % 5;
+                        } else {
+                            app.switch_tab((app.selected_tab + 1) % 4);
+                        }
                     }
                     KeyCode::BackTab => {
-                        // Cycle through tabs backwards
-                        app.switch_tab((app.selected_tab + 3) % 4);
+                        if app.selected_tab == 1 && app.detailed_view {
+                            app.step_inspector_tab = (app.step_inspector_tab + 4) % 5;
+                        } else {
+                            app.switch_tab((app.selected_tab + 3) % 4);
+                        }
                     }
                     KeyCode::Char('1') | KeyCode::Char('w') => app.switch_tab(0),
                     KeyCode::Char('2') | KeyCode::Char('x') => app.switch_tab(1),

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -95,6 +95,10 @@ pub struct App {
     /// task failure, so we don't tell the user "evaluation failed" for an
     /// action they took deliberately. Cleared once observed.
     pub diff_filter_aborted: bool,
+
+    /// Active sub-tab inside the Step Inspector (job-detail) view.
+    /// 0 Output, 1 Env, 2 Files, 3 Matrix, 4 Timeline.
+    pub step_inspector_tab: usize,
 }
 
 /// Result rows shipped from the background diff-filter task to the UI loop.
@@ -335,6 +339,7 @@ impl App {
             diff_filter_rx: None,
             diff_filter_task: None,
             diff_filter_aborted: false,
+            step_inspector_tab: 0,
         }
     }
 
@@ -1875,6 +1880,7 @@ mod tests {
                 execution_details: None,
                 job_names: vec!["build".to_string(), "lint".to_string(), "test".to_string()],
                 trigger_match: None,
+                definition: None,
             },
             Workflow {
                 name: "deploy".to_string(),
@@ -1884,6 +1890,7 @@ mod tests {
                 execution_details: None,
                 job_names: vec![],
                 trigger_match: None,
+                definition: None,
             },
         ];
         app.workflow_list_state.select(Some(0));
@@ -2024,6 +2031,7 @@ mod tests {
                 execution_details: None,
                 job_names: vec![],
                 trigger_match: None,
+                definition: None,
             },
             Workflow {
                 name: "ci".into(),
@@ -2033,6 +2041,7 @@ mod tests {
                 execution_details: None,
                 job_names: vec![],
                 trigger_match: None,
+                definition: None,
             },
         ];
 

--- a/crates/ui/src/components/dag.rs
+++ b/crates/ui/src/components/dag.rs
@@ -173,10 +173,7 @@ pub fn render<F: Fn(&str) -> NodeState>(
                         color
                     }),
                 ),
-                Span::styled(
-                    active_marker.to_string(),
-                    Style::default().fg(COLORS.info),
-                ),
+                Span::styled(active_marker.to_string(), Style::default().fg(COLORS.info)),
             ]));
         }
     }

--- a/crates/ui/src/components/dag.rs
+++ b/crates/ui/src/components/dag.rs
@@ -1,0 +1,208 @@
+// Mini job-dependency view.
+//
+// The design's full DAG is a free-form SVG; in a terminal we render a tighter
+// columns-by-topological-level layout using box-drawing chars. When `needs:`
+// data is unavailable we fall back to a single linear column so the panel
+// is never empty.
+
+use crate::theme::{self, BadgeKind, COLORS};
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+use std::collections::{HashMap, HashSet};
+use wrkflw_parser::workflow::WorkflowDefinition;
+
+/// Status of a job *as it appears live* — synthesised from `WorkflowExecution`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NodeState {
+    Success,
+    Failure,
+    Skipped,
+    Running,
+    Pending,
+}
+
+fn state_color(s: NodeState) -> ratatui::style::Color {
+    match s {
+        NodeState::Success => COLORS.success,
+        NodeState::Failure => COLORS.error,
+        NodeState::Skipped => COLORS.warning,
+        NodeState::Running => COLORS.info,
+        NodeState::Pending => COLORS.text_muted,
+    }
+}
+
+fn state_glyph(s: NodeState, spinner_frame: usize) -> &'static str {
+    match s {
+        NodeState::Success => theme::symbols::SUCCESS,
+        NodeState::Failure => theme::symbols::FAILURE,
+        NodeState::Skipped => theme::symbols::SKIPPED,
+        NodeState::Running => theme::spinner(spinner_frame),
+        NodeState::Pending => theme::symbols::NOT_STARTED,
+    }
+}
+
+/// Compute topological levels (Kahn's algorithm). Returns columns of job names.
+/// Jobs not present in the dependency graph go into the first column.
+pub fn topo_levels(def: &WorkflowDefinition) -> Vec<Vec<String>> {
+    let names: Vec<String> = {
+        let mut v: Vec<String> = def.jobs.keys().cloned().collect();
+        v.sort();
+        v
+    };
+    let name_set: HashSet<&str> = names.iter().map(|s| s.as_str()).collect();
+
+    // Build "needs" map restricted to known jobs only.
+    let mut needs: HashMap<String, Vec<String>> = HashMap::new();
+    for n in &names {
+        let job = &def.jobs[n];
+        let req: Vec<String> = job
+            .needs
+            .as_ref()
+            .map(|v| {
+                v.iter()
+                    .filter(|d| name_set.contains(d.as_str()))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        needs.insert(n.clone(), req);
+    }
+
+    let mut placed: HashSet<String> = HashSet::new();
+    let mut levels: Vec<Vec<String>> = Vec::new();
+
+    while placed.len() < names.len() {
+        let mut layer: Vec<String> = Vec::new();
+        for n in &names {
+            if placed.contains(n) {
+                continue;
+            }
+            let deps = &needs[n];
+            if deps.iter().all(|d| placed.contains(d)) {
+                layer.push(n.clone());
+            }
+        }
+        if layer.is_empty() {
+            // Cycle / unresolved — drop remaining jobs into a final column.
+            let rest: Vec<String> = names
+                .iter()
+                .filter(|n| !placed.contains(*n))
+                .cloned()
+                .collect();
+            placed.extend(rest.iter().cloned());
+            levels.push(rest);
+            break;
+        }
+        for n in &layer {
+            placed.insert(n.clone());
+        }
+        levels.push(layer);
+    }
+    levels
+}
+
+/// Render the mini DAG into `area`. `state_of` resolves a job name to its
+/// current node state.
+pub fn render<F: Fn(&str) -> NodeState>(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    def: Option<&WorkflowDefinition>,
+    state_of: F,
+    spinner_frame: usize,
+) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    let levels: Vec<Vec<String>> = match def {
+        Some(d) => topo_levels(d),
+        None => Vec::new(),
+    };
+
+    if levels.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "no parsed workflow",
+            Style::default().fg(COLORS.text_muted),
+        )));
+        frame.render_widget(Paragraph::new(lines), area);
+        return;
+    }
+
+    // Render one row per (column, name) up to a few — narrow text panel.
+    // Format:  L1: setup   ✓
+    //          L2: fmt     ✓
+    //              clippy  ✓
+    //          L3: build   ⠋  ◀
+    let stage_labels = ["setup", "lint", "build", "test/docs", "publish"];
+    for (li, layer) in levels.iter().enumerate() {
+        // Stage header
+        let stage = stage_labels.get(li).copied().unwrap_or("stage");
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("L{} ", li + 1),
+                Style::default().fg(COLORS.text_muted),
+            ),
+            Span::styled(
+                stage.to_string(),
+                Style::default()
+                    .fg(COLORS.highlight)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        for name in layer {
+            let st = state_of(name);
+            let color = state_color(st);
+            let glyph = state_glyph(st, spinner_frame);
+            let active_marker = if matches!(st, NodeState::Running) {
+                "  ◀"
+            } else {
+                ""
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(glyph.to_string(), Style::default().fg(color)),
+                Span::raw(" "),
+                Span::styled(
+                    truncate(name, 14),
+                    Style::default().fg(if matches!(st, NodeState::Running) {
+                        COLORS.text
+                    } else {
+                        color
+                    }),
+                ),
+                Span::styled(
+                    active_marker.to_string(),
+                    Style::default().fg(COLORS.info),
+                ),
+            ]));
+        }
+    }
+
+    // Tiny legend strip (matches the design's "active critical path" idea).
+    lines.push(Line::from(vec![Span::styled(
+        " ",
+        Style::default().fg(COLORS.text_muted),
+    )]));
+    lines.push(Line::from(vec![
+        theme::badge_outline("running", BadgeKind::Info),
+        Span::raw(" "),
+        theme::badge_outline("done", BadgeKind::Success),
+        Span::raw(" "),
+        theme::badge_outline("pending", BadgeKind::Dim),
+    ]));
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(n.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -3,10 +3,11 @@ mod button;
 mod checkbox;
 mod progress_bar;
 
+pub mod dag;
+pub mod progress_dots;
+pub mod timing;
+
 // Re-export components for easier access
 pub use button::Button;
 pub use checkbox::Checkbox;
 pub use progress_bar::ProgressBar;
-
-// This module will contain smaller reusable UI elements that
-// can be shared between different views of the application.

--- a/crates/ui/src/components/progress_dots.rs
+++ b/crates/ui/src/components/progress_dots.rs
@@ -1,0 +1,86 @@
+// Step-progress dots strip — one short bar per step, coloured by status.
+// Mirrors the design's `<ProgressDots/>` component in screens-core.jsx.
+
+use crate::models::WorkflowStatus;
+use crate::theme::COLORS;
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+use wrkflw_executor::StepStatus;
+
+/// State of a single dot. Live state isn't carried by `StepStatus` (which
+/// only models terminal outcomes), so callers pass a synthesised tag.
+#[derive(Copy, Clone, Debug)]
+pub enum DotState {
+    Success,
+    Failure,
+    Skipped,
+    Running,
+    Pending,
+}
+
+impl DotState {
+    pub fn from_step(s: &StepStatus) -> Self {
+        match s {
+            StepStatus::Success => DotState::Success,
+            StepStatus::Failure => DotState::Failure,
+            StepStatus::Skipped => DotState::Skipped,
+        }
+    }
+}
+
+fn dot_style(state: DotState) -> Style {
+    let c = match state {
+        DotState::Success => COLORS.success,
+        DotState::Failure => COLORS.error,
+        DotState::Skipped => COLORS.warning,
+        DotState::Running => COLORS.info,
+        DotState::Pending => COLORS.border,
+    };
+    Style::default().fg(c)
+}
+
+/// Render a horizontal strip of progress segments and a `done/total` counter.
+pub fn render(frame: &mut Frame<'_>, area: Rect, dots: &[DotState], done: usize, total: usize) {
+    if total == 0 {
+        return;
+    }
+    let mut spans: Vec<Span> = Vec::with_capacity(dots.len() * 2 + 2);
+    for d in dots {
+        spans.push(Span::styled("▆", dot_style(*d)));
+        spans.push(Span::raw(" "));
+    }
+    spans.push(Span::styled(
+        format!(" {}/{} ", done, total),
+        Style::default().fg(COLORS.text_dim),
+    ));
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Convenience: build a `Vec<DotState>` from terminal step statuses, padding
+/// with `Pending` and marking the next-pending slot `Running` if the workflow
+/// is currently active.
+pub fn synthesise(
+    completed: &[StepStatus],
+    total: usize,
+    workflow_status: &WorkflowStatus,
+) -> Vec<DotState> {
+    let mut out: Vec<DotState> = completed.iter().map(DotState::from_step).collect();
+    let pending = total.saturating_sub(out.len());
+    if pending == 0 {
+        return out;
+    }
+    let next_is_running = matches!(workflow_status, WorkflowStatus::Running);
+    for i in 0..pending {
+        if i == 0 && next_is_running {
+            out.push(DotState::Running);
+        } else {
+            out.push(DotState::Pending);
+        }
+    }
+    out
+}

--- a/crates/ui/src/components/timing.rs
+++ b/crates/ui/src/components/timing.rs
@@ -1,0 +1,115 @@
+// Per-job timing chart — horizontal bars sized against the longest run.
+//
+// We don't have per-job wall-clock timing today (executor only reports terminal
+// statuses, no `started_at` per job). For now we render uniform-width bars
+// coloured by status so the panel is visually present and honest. When timing
+// metadata lands later, swap `weight=1.0` for `(elapsed / max).min(1.0)`.
+
+use crate::theme::COLORS;
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+use wrkflw_executor::JobStatus;
+
+#[derive(Clone)]
+pub struct TimingRow<'a> {
+    pub name: &'a str,
+    pub status: Option<JobStatus>, // None = pending
+    pub label: &'a str,            // e.g. "1m 47s" or "—"
+}
+
+pub fn render(frame: &mut Frame<'_>, area: Rect, rows: &[TimingRow]) {
+    if area.width < 12 {
+        return;
+    }
+    // We aim for: NAME (10) | BAR (rest - 6) | LABEL (5)
+    let bar_width = area.width.saturating_sub(18) as usize;
+    let mut lines: Vec<Line> = Vec::with_capacity(rows.len());
+    for row in rows {
+        let (color, fill) = bar_props(row.status.clone());
+        let filled = (fill * bar_width as f32).round() as usize;
+        let empty = bar_width.saturating_sub(filled);
+
+        lines.push(Line::from(vec![
+            Span::styled(
+                pad_right(row.name, 10),
+                Style::default().fg(COLORS.text_dim),
+            ),
+            Span::styled("█".repeat(filled), Style::default().fg(color)),
+            Span::styled("·".repeat(empty), Style::default().fg(COLORS.border)),
+            Span::raw(" "),
+            Span::styled(
+                pad_left(row.label, 5),
+                Style::default().fg(COLORS.text_muted),
+            ),
+        ]));
+    }
+    if rows.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "no jobs yet",
+            Style::default().fg(COLORS.text_muted),
+        )));
+    } else {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "critical path ",
+                Style::default()
+                    .fg(COLORS.text_muted)
+                    .add_modifier(Modifier::DIM),
+            ),
+            Span::styled(
+                summarise(rows),
+                Style::default().fg(COLORS.text_dim),
+            ),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn bar_props(s: Option<JobStatus>) -> (ratatui::style::Color, f32) {
+    match s {
+        Some(JobStatus::Success) => (COLORS.success, 1.0),
+        Some(JobStatus::Failure) => (COLORS.error, 1.0),
+        Some(JobStatus::Skipped) => (COLORS.warning, 0.4),
+        None => (COLORS.info, 0.0), // pending — empty
+    }
+}
+
+fn pad_right(s: &str, n: usize) -> String {
+    let mut out: String = s.chars().take(n).collect();
+    while out.chars().count() < n {
+        out.push(' ');
+    }
+    out
+}
+
+fn pad_left(s: &str, n: usize) -> String {
+    let count = s.chars().count();
+    if count >= n {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    for _ in 0..(n - count) {
+        out.push(' ');
+    }
+    out.push_str(s);
+    out
+}
+
+fn summarise(rows: &[TimingRow]) -> String {
+    let names: Vec<&str> = rows
+        .iter()
+        .filter(|r| matches!(r.status, Some(JobStatus::Success | JobStatus::Failure)))
+        .map(|r| r.name)
+        .collect();
+    if names.is_empty() {
+        "(awaiting first job)".to_string()
+    } else {
+        names.join(" → ")
+    }
+}

--- a/crates/ui/src/components/timing.rs
+++ b/crates/ui/src/components/timing.rs
@@ -62,10 +62,7 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, rows: &[TimingRow]) {
                     .fg(COLORS.text_muted)
                     .add_modifier(Modifier::DIM),
             ),
-            Span::styled(
-                summarise(rows),
-                Style::default().fg(COLORS.text_dim),
-            ),
+            Span::styled(summarise(rows), Style::default().fg(COLORS.text_dim)),
         ]));
     }
     frame.render_widget(Paragraph::new(lines), area);

--- a/crates/ui/src/models/mod.rs
+++ b/crates/ui/src/models/mod.rs
@@ -1,8 +1,10 @@
 // UI Models for wrkflw
 use chrono::Local;
 use std::path::PathBuf;
+use std::sync::Arc;
 use wrkflw_executor::{JobStatus, StepStatus};
 use wrkflw_logging::symbols;
+use wrkflw_parser::workflow::WorkflowDefinition;
 
 /// Type alias for the complex execution result type
 pub type ExecutionResultMsg = (usize, Result<(Vec<wrkflw_executor::JobResult>, ()), String>);
@@ -25,6 +27,10 @@ pub struct Workflow {
     pub execution_details: Option<WorkflowExecution>,
     pub job_names: Vec<String>,
     pub trigger_match: Option<TriggerMatchStatus>,
+    /// Parsed workflow definition. Populated at load time so the Dashboard
+    /// preview / mini-DAG don't have to reparse on every render. `None` when
+    /// the file failed to parse (we still show the row so the user sees it).
+    pub definition: Option<Arc<WorkflowDefinition>>,
 }
 
 /// A workflow queued for execution, with its own target job

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,6 +1,6 @@
 // Centralized theme for wrkflw TUI
 //
-// All colors, styles, and symbols are defined here.
+// Palette and symbol set match the design handoff in `wrkflw TUI.html`.
 // View files import from this module instead of hardcoding.
 
 use ratatui::{
@@ -34,6 +34,7 @@ pub struct Colors {
 
     // Backgrounds
     pub bg_selected: Color,
+    pub bg_panel: Color,
     pub bg_bar: Color,
     pub bg_dark: Color,
 
@@ -45,99 +46,92 @@ pub struct Colors {
 }
 
 pub const COLORS: Colors = Colors {
-    accent: Color::Cyan,
-    highlight: Color::Yellow,
+    accent: Color::Rgb(0x5f, 0xd3, 0xf3),
+    highlight: Color::Rgb(0xf5, 0xd7, 0x6e),
 
-    success: Color::Green,
-    error: Color::Red,
-    warning: Color::Yellow,
-    info: Color::Cyan,
-    trigger: Color::Magenta,
+    success: Color::Rgb(0x8f, 0xce, 0x8f),
+    error: Color::Rgb(0xff, 0x7a, 0x7a),
+    warning: Color::Rgb(0xf5, 0xd7, 0x6e),
+    info: Color::Rgb(0x5f, 0xd3, 0xf3),
+    trigger: Color::Rgb(0xd6, 0x8c, 0xff),
 
-    text: Color::White,
-    text_dim: Color::Gray,
-    text_muted: Color::DarkGray,
+    text: Color::Rgb(0xd7, 0xdd, 0xe4),
+    text_dim: Color::Rgb(0x88, 0x90, 0xa0),
+    text_muted: Color::Rgb(0x56, 0x5e, 0x6b),
 
-    border: Color::DarkGray,
-    border_focused: Color::Cyan,
+    border: Color::Rgb(0x2a, 0x2f, 0x38),
+    border_focused: Color::Rgb(0x5f, 0xd3, 0xf3),
 
-    bg_selected: Color::Rgb(40, 44, 52),
-    bg_bar: Color::DarkGray,
-    bg_dark: Color::Black,
+    bg_selected: Color::Rgb(0x1a, 0x20, 0x28),
+    bg_panel: Color::Rgb(0x0f, 0x12, 0x16),
+    bg_bar: Color::Rgb(0x14, 0x17, 0x1c),
+    bg_dark: Color::Rgb(0x07, 0x09, 0x0b),
 
-    runtime_docker: Color::Blue,
-    runtime_podman: Color::Cyan,
-    runtime_emulation: Color::Red,
-    runtime_secure: Color::Green,
+    runtime_docker: Color::Rgb(0x5f, 0xa3, 0xff),
+    runtime_podman: Color::Rgb(0x5f, 0xd3, 0xf3),
+    runtime_emulation: Color::Rgb(0xff, 0x99, 0x66),
+    runtime_secure: Color::Rgb(0x8f, 0xce, 0x8f),
 };
 
 // ── Symbols ────────────────────────────────────────────────────────
 
-/// Re-export the shared symbol constants from `wrkflw_logging::symbols`.
-/// All crates use a single source of truth for Unicode symbols.
 pub use wrkflw_logging::symbols;
 
 // ── Style Helpers ──────────────────────────────────────────────────
 
-/// Style for section/block titles
 pub fn title_style() -> Style {
     Style::default()
         .fg(COLORS.highlight)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Style for the wrkflw brand title
 pub fn brand_style() -> Style {
     Style::default()
         .fg(COLORS.accent)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Style for field labels ("Workflow:", "Status:", etc.)
 pub fn label_style() -> Style {
     Style::default().fg(COLORS.accent)
 }
 
-/// Style for selected/highlighted rows
 pub fn selected_style() -> Style {
     Style::default()
         .bg(COLORS.bg_selected)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Style for table/column headers
 pub fn header_style() -> Style {
     Style::default()
         .fg(COLORS.highlight)
-        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-}
-
-/// Style for search match highlighting
-pub fn search_highlight() -> Style {
-    Style::default()
-        .bg(COLORS.highlight)
-        .fg(Color::Black)
         .add_modifier(Modifier::BOLD)
 }
 
-/// Style for dimmed/secondary text
+pub fn search_highlight() -> Style {
+    Style::default()
+        .bg(COLORS.highlight)
+        .fg(COLORS.bg_dark)
+        .add_modifier(Modifier::BOLD)
+}
+
 pub fn dim_style() -> Style {
     Style::default().fg(COLORS.text_dim)
 }
 
-/// Style for muted text (paths, timestamps)
 pub fn muted_style() -> Style {
     Style::default().fg(COLORS.text_muted)
 }
 
-/// Style for key hints in status bar ("[Enter]", "[Space]")
 pub fn key_style() -> Style {
     Style::default().fg(COLORS.highlight)
 }
 
-/// Style for hint descriptions in status bar
 pub fn hint_style() -> Style {
     Style::default().fg(COLORS.text_dim)
+}
+
+pub fn panel_style() -> Style {
+    Style::default().bg(COLORS.bg_panel)
 }
 
 // ── Status Styles ──────────────────────────────────────────────────
@@ -145,10 +139,9 @@ pub fn hint_style() -> Style {
 use crate::models::WorkflowStatus;
 use wrkflw_executor::{JobStatus, StepStatus};
 
-/// Get symbol and style for a WorkflowStatus
 pub fn workflow_status(status: &WorkflowStatus) -> (&'static str, Style) {
     match status {
-        WorkflowStatus::NotStarted => (symbols::NOT_STARTED, Style::default().fg(COLORS.text_dim)),
+        WorkflowStatus::NotStarted => (symbols::NOT_STARTED, Style::default().fg(COLORS.text_muted)),
         WorkflowStatus::Running => (symbols::RUNNING, Style::default().fg(COLORS.info)),
         WorkflowStatus::Success => (symbols::SUCCESS, Style::default().fg(COLORS.success)),
         WorkflowStatus::Failed => (symbols::FAILURE, Style::default().fg(COLORS.error)),
@@ -156,12 +149,10 @@ pub fn workflow_status(status: &WorkflowStatus) -> (&'static str, Style) {
     }
 }
 
-/// Get animated spinner symbol for running state
 pub fn spinner(frame: usize) -> &'static str {
     symbols::SPINNER[frame % symbols::SPINNER.len()]
 }
 
-/// Get symbol and style for a WorkflowStatus with spinner animation
 pub fn workflow_status_animated(
     status: &WorkflowStatus,
     spinner_frame: usize,
@@ -172,27 +163,24 @@ pub fn workflow_status_animated(
     }
 }
 
-/// Get symbol and style for a JobStatus
 pub fn job_status(status: &JobStatus) -> (&'static str, Style) {
     match status {
         JobStatus::Success => (symbols::SUCCESS, Style::default().fg(COLORS.success)),
         JobStatus::Failure => (symbols::FAILURE, Style::default().fg(COLORS.error)),
-        JobStatus::Skipped => (symbols::SKIPPED, Style::default().fg(COLORS.text_dim)),
+        JobStatus::Skipped => (symbols::SKIPPED, Style::default().fg(COLORS.text_muted)),
     }
 }
 
-/// Get symbol and style for a StepStatus
 pub fn step_status(status: &StepStatus) -> (&'static str, Style) {
     match status {
         StepStatus::Success => (symbols::SUCCESS, Style::default().fg(COLORS.success)),
         StepStatus::Failure => (symbols::FAILURE, Style::default().fg(COLORS.error)),
-        StepStatus::Skipped => (symbols::SKIPPED, Style::default().fg(COLORS.text_dim)),
+        StepStatus::Skipped => (symbols::SKIPPED, Style::default().fg(COLORS.text_muted)),
     }
 }
 
 // ── Block Helpers ──────────────────────────────────────────────────
 
-/// Create a styled block with rounded borders and a title
 pub fn block<'a>(title: &'a str) -> Block<'a> {
     Block::default()
         .borders(Borders::ALL)
@@ -201,7 +189,6 @@ pub fn block<'a>(title: &'a str) -> Block<'a> {
         .title(Span::styled(format!(" {} ", title), title_style()))
 }
 
-/// Create a styled block with focused (accent) border
 pub fn block_focused<'a>(title: &'a str) -> Block<'a> {
     Block::default()
         .borders(Borders::ALL)
@@ -212,16 +199,93 @@ pub fn block_focused<'a>(title: &'a str) -> Block<'a> {
 
 // ── Badge Helpers ──────────────────────────────────────────────────
 
-/// Create a styled badge span (text with colored background)
+#[derive(Copy, Clone, Debug)]
+pub enum BadgeKind {
+    Info,
+    Success,
+    Error,
+    Warning,
+    Trigger,
+    Dim,
+    Accent,
+    Highlight,
+    Docker,
+    Podman,
+    Emulation,
+    Secure,
+}
+
+impl BadgeKind {
+    pub fn fg(self) -> Color {
+        match self {
+            BadgeKind::Info => COLORS.info,
+            BadgeKind::Success => COLORS.success,
+            BadgeKind::Error => COLORS.error,
+            BadgeKind::Warning => COLORS.warning,
+            BadgeKind::Trigger => COLORS.trigger,
+            BadgeKind::Dim => COLORS.text_dim,
+            BadgeKind::Accent => COLORS.accent,
+            BadgeKind::Highlight => COLORS.highlight,
+            BadgeKind::Docker => COLORS.runtime_docker,
+            BadgeKind::Podman => COLORS.runtime_podman,
+            BadgeKind::Emulation => COLORS.runtime_emulation,
+            BadgeKind::Secure => COLORS.runtime_secure,
+        }
+    }
+}
+
+/// Outline badge: small chip with colored text on the panel background.
+pub fn badge_outline<'a>(text: impl Into<String>, kind: BadgeKind) -> Span<'a> {
+    Span::styled(
+        format!(" {} ", text.into()),
+        Style::default().fg(kind.fg()).add_modifier(Modifier::BOLD),
+    )
+}
+
+/// Solid badge: dark text on a colored background.
+pub fn badge_solid<'a>(text: impl Into<String>, kind: BadgeKind) -> Span<'a> {
+    Span::styled(
+        format!(" {} ", text.into()),
+        Style::default()
+            .bg(kind.fg())
+            .fg(COLORS.bg_dark)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+/// Legacy badge helper kept for callers that already pass explicit colors.
 pub fn badge<'a>(text: &'a str, bg: Color, fg: Color) -> Span<'a> {
     Span::styled(format!(" {} ", text), Style::default().bg(bg).fg(fg))
+}
+
+/// Render a key hint as a keycap chip: `[K]` in highlight on bg_bar.
+pub fn key_chip<'a>(key: impl Into<String>) -> Span<'a> {
+    Span::styled(
+        format!(" {} ", key.into()),
+        Style::default()
+            .bg(COLORS.bg_bar)
+            .fg(COLORS.highlight)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+/// Pulsing style for the LIVE indicator dot.
+pub fn pulse_style(frame: usize) -> Style {
+    let dim = (frame / 4).is_multiple_of(2);
+    let mut s = Style::default().fg(COLORS.error);
+    if dim {
+        s = s.add_modifier(Modifier::DIM);
+    } else {
+        s = s.add_modifier(Modifier::BOLD);
+    }
+    s
 }
 
 /// Log level badge styles
 pub fn log_badge(level: &str) -> Style {
     match level {
-        "ERROR" => Style::default().bg(COLORS.error).fg(COLORS.text),
-        "WARN" => Style::default().bg(COLORS.warning).fg(Color::Black),
+        "ERROR" => Style::default().bg(COLORS.error).fg(COLORS.bg_dark),
+        "WARN" => Style::default().bg(COLORS.warning).fg(COLORS.bg_dark),
         "SUCCESS" => Style::default().fg(COLORS.success),
         "INFO" => Style::default().fg(COLORS.info),
         "TRIG" => Style::default().fg(COLORS.trigger),

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -141,7 +141,9 @@ use wrkflw_executor::{JobStatus, StepStatus};
 
 pub fn workflow_status(status: &WorkflowStatus) -> (&'static str, Style) {
     match status {
-        WorkflowStatus::NotStarted => (symbols::NOT_STARTED, Style::default().fg(COLORS.text_muted)),
+        WorkflowStatus::NotStarted => {
+            (symbols::NOT_STARTED, Style::default().fg(COLORS.text_muted))
+        }
         WorkflowStatus::Running => (symbols::RUNNING, Style::default().fg(COLORS.info)),
         WorkflowStatus::Success => (symbols::SUCCESS, Style::default().fg(COLORS.success)),
         WorkflowStatus::Failed => (symbols::FAILURE, Style::default().fg(COLORS.error)),

--- a/crates/ui/src/utils/mod.rs
+++ b/crates/ui/src/utils/mod.rs
@@ -1,18 +1,27 @@
 // UI utilities
 use crate::models::{Workflow, WorkflowStatus};
 use std::path::{Path, PathBuf};
-use wrkflw_parser::workflow::parse_workflow;
+use std::sync::Arc;
+use wrkflw_parser::workflow::{parse_workflow, WorkflowDefinition};
 use wrkflw_utils::is_workflow_file;
+
+/// Parse a workflow file once and return both the parsed definition and a
+/// sorted job-name list. The definition is shared so view code can read it
+/// without reparsing on every frame.
+fn load_definition(path: &Path) -> (Option<Arc<WorkflowDefinition>>, Vec<String>) {
+    match parse_workflow(path) {
+        Ok(def) => {
+            let mut names: Vec<String> = def.jobs.keys().cloned().collect();
+            names.sort();
+            (Some(Arc::new(def)), names)
+        }
+        Err(_) => (None, Vec::new()),
+    }
+}
 
 /// Parse a workflow file and return sorted job names, or an empty vec on failure.
 pub fn extract_job_names(path: &Path) -> Vec<String> {
-    parse_workflow(path)
-        .map(|wf| {
-            let mut names: Vec<String> = wf.jobs.keys().cloned().collect();
-            names.sort();
-            names
-        })
-        .unwrap_or_default()
+    load_definition(path).1
 }
 
 /// Find and load all workflow files in a directory
@@ -33,7 +42,7 @@ pub fn load_workflows(dir_path: &Path) -> Vec<Workflow> {
                     |fname| fname.to_string_lossy().into_owned(),
                 );
 
-                let job_names = extract_job_names(&path);
+                let (definition, job_names) = load_definition(&path);
 
                 workflows.push(Workflow {
                     name,
@@ -43,6 +52,7 @@ pub fn load_workflows(dir_path: &Path) -> Vec<Workflow> {
                     execution_details: None,
                     job_names,
                     trigger_match: None,
+                    definition,
                 });
             }
         }
@@ -53,7 +63,7 @@ pub fn load_workflows(dir_path: &Path) -> Vec<Workflow> {
         // Look for .gitlab-ci.yml in the repository root
         let gitlab_ci_path = PathBuf::from(".gitlab-ci.yml");
         if gitlab_ci_path.exists() && gitlab_ci_path.is_file() {
-            let job_names = extract_job_names(&gitlab_ci_path);
+            let (definition, job_names) = load_definition(&gitlab_ci_path);
 
             workflows.push(Workflow {
                 name: "gitlab-ci".to_string(),
@@ -63,6 +73,7 @@ pub fn load_workflows(dir_path: &Path) -> Vec<Workflow> {
                 execution_details: None,
                 job_names,
                 trigger_match: None,
+                definition,
             });
         }
     }

--- a/crates/ui/src/views/execution_tab.rs
+++ b/crates/ui/src/views/execution_tab.rs
@@ -1,287 +1,455 @@
-// Execution tab rendering
+// Live Run — three-pane layout (Jobs · Steps + Live output · Mini DAG + Timing).
+//
+// Mirrors `LiveRunScreen` in screens-core.jsx of the design handoff. Where the
+// design uses synthetic per-job timing and per-step env capture, we render the
+// fields we actually have (status, names, workflow elapsed) and clearly mark
+// the rest as not yet captured.
+
 use crate::app::App;
+use crate::components::{
+    dag,
+    progress_dots::{self, DotState},
+    timing::{self, TimingRow},
+};
 use crate::models::WorkflowStatus;
-use crate::theme::{self, COLORS};
+use crate::theme::{self, BadgeKind, COLORS};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Gauge, List, ListItem, Paragraph},
+    widgets::{Paragraph, Wrap},
     Frame,
 };
+use wrkflw_executor::{JobStatus, RuntimeType, StepStatus};
 
-// Render the execution tab
+const RIGHT_PANE_WIDTH: u16 = 40;
+const LEFT_PANE_WIDTH: u16 = 30;
+
 pub fn render_execution_tab(f: &mut Frame<'_>, app: &mut App, area: Rect) {
-    let current_workflow_idx = app
+    let workflow_idx = app
         .current_execution
         .or_else(|| app.workflow_list_state.selected())
         .filter(|&idx| idx < app.workflows.len());
 
-    if let Some(idx) = current_workflow_idx {
-        let workflow = &app.workflows[idx];
+    let Some(idx) = workflow_idx else {
+        render_empty_state(f, area);
+        return;
+    };
 
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(
-                [
-                    Constraint::Length(5), // Workflow info with progress bar
-                    Constraint::Min(5),    // Jobs list
-                    Constraint::Length(7), // Execution info
-                ]
-                .as_ref(),
-            )
-            .margin(1)
-            .split(area);
+    let workflow = &app.workflows[idx];
 
-        // Workflow info section
-        let (status_text, status_style) = match workflow.status {
-            WorkflowStatus::NotStarted => ("Not Started", Style::default().fg(COLORS.text_dim)),
-            WorkflowStatus::Running => ("Running", Style::default().fg(COLORS.info)),
-            WorkflowStatus::Success => ("Success", Style::default().fg(COLORS.success)),
-            WorkflowStatus::Failed => ("Failed", Style::default().fg(COLORS.error)),
-            WorkflowStatus::Skipped => ("Skipped", Style::default().fg(COLORS.warning)),
+    // ── Vertical split: summary strip + main pane ─────────────────
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(area);
+
+    render_summary_strip(f, app, idx, outer[0]);
+
+    let main = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(LEFT_PANE_WIDTH),
+            Constraint::Min(0),
+            Constraint::Length(RIGHT_PANE_WIDTH),
+        ])
+        .split(outer[1]);
+
+    render_jobs_pane(f, app, idx, main[0]);
+
+    let centre = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Min(0)])
+        .split(main[1]);
+    render_steps_pane(f, workflow, centre[0]);
+    render_live_output_pane(f, app, centre[1]);
+
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(60), Constraint::Min(0)])
+        .split(main[2]);
+    render_dag_pane(f, app, idx, right[0]);
+    render_timing_pane(f, workflow, right[1]);
+}
+
+// ─── Summary strip (workflow chip + progress dots + meta) ────────
+fn render_summary_strip(f: &mut Frame<'_>, app: &App, idx: usize, area: Rect) {
+    let workflow = &app.workflows[idx];
+    let block = theme::block("Run");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(28)])
+        .split(inner_area);
+
+    // Left: workflow chip
+    let (sym, sym_style) = theme::workflow_status_animated(&workflow.status, app.spinner_frame);
+    let runtime_kind = match app.runtime_type {
+        RuntimeType::Docker => BadgeKind::Docker,
+        RuntimeType::Podman => BadgeKind::Podman,
+        RuntimeType::SecureEmulation => BadgeKind::Secure,
+        RuntimeType::Emulation => BadgeKind::Emulation,
+    };
+
+    let mut left_spans: Vec<Span> = vec![
+        Span::styled(sym.to_string(), sym_style),
+        Span::raw(" "),
+        Span::styled(
+            workflow.name.clone(),
+            Style::default()
+                .fg(COLORS.text)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  ·  ", Style::default().fg(COLORS.text_muted)),
+    ];
+    if let Some(exec) = workflow.execution_details.as_ref() {
+        left_spans.push(Span::styled(
+            exec.start_time.format("%H:%M:%S").to_string(),
+            Style::default().fg(COLORS.text_dim),
+        ));
+        left_spans.push(Span::styled(
+            "  ·  ",
+            Style::default().fg(COLORS.text_muted),
+        ));
+    }
+    left_spans.push(theme::badge_outline(app.runtime_type_name(), runtime_kind));
+
+    f.render_widget(
+        Paragraph::new(Line::from(left_spans)).alignment(Alignment::Left),
+        chunks[0],
+    );
+
+    // Right: progress dots over the active job's steps
+    if let Some(active_job) = active_job_execution(workflow) {
+        let total = active_job.steps.len();
+        let dots = progress_dots::synthesise(
+            &active_job
+                .steps
+                .iter()
+                .map(|s| s.status)
+                .collect::<Vec<_>>(),
+            total,
+            &workflow.status,
+        );
+        let done = dots
+            .iter()
+            .filter(|d| matches!(d, DotState::Success | DotState::Failure | DotState::Skipped))
+            .count();
+        progress_dots::render(f, chunks[1], &dots, done, total);
+    }
+}
+
+// ─── Jobs pane (left) ─────────────────────────────────────────────
+fn render_jobs_pane(f: &mut Frame<'_>, app: &App, idx: usize, area: Rect) {
+    let block = theme::block("Jobs");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let workflow = &app.workflows[idx];
+    let exec = workflow.execution_details.as_ref();
+
+    // Synthesise full job list from workflow.job_names; jobs in `exec.jobs`
+    // get their real status, the rest are pending (or running for the next slot).
+    let mut lines: Vec<Line> = Vec::new();
+    let active_name = active_job_name(workflow);
+    for (i, name) in workflow.job_names.iter().enumerate() {
+        let job_exec = exec.and_then(|e| e.jobs.iter().find(|j| j.name == *name));
+        let (sym, sym_style) = match (job_exec, active_name.as_deref() == Some(name)) {
+            (Some(j), _) => theme::job_status(&j.status),
+            (None, true) => (theme::spinner(app.spinner_frame), Style::default().fg(COLORS.info)),
+            (None, false) => (theme::symbols::NOT_STARTED, Style::default().fg(COLORS.text_muted)),
         };
-
-        let mut workflow_info = vec![
-            Line::from(vec![
-                Span::styled("Workflow: ", theme::label_style()),
-                Span::styled(
-                    workflow.name.clone(),
-                    Style::default()
-                        .fg(COLORS.text)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Status: ", theme::label_style()),
-                Span::styled(status_text, status_style),
-            ]),
-        ];
-
-        if let Some(execution) = &workflow.execution_details {
-            let progress = execution.progress;
-
-            let gauge_color = match workflow.status {
-                WorkflowStatus::Running => COLORS.info,
-                WorkflowStatus::Success => COLORS.success,
-                WorkflowStatus::Failed => COLORS.error,
-                _ => COLORS.text_dim,
-            };
-
-            let progress_text = match workflow.status {
-                WorkflowStatus::Running => format!("{:.0}%", progress * 100.0),
-                WorkflowStatus::Success => "Completed".to_string(),
-                WorkflowStatus::Failed => "Failed".to_string(),
-                _ => "Not started".to_string(),
-            };
-
-            workflow_info.push(Line::from(""));
-            workflow_info.push(Line::from(vec![
-                Span::styled("Progress: ", theme::label_style()),
-                Span::styled(progress_text, Style::default().fg(COLORS.text_dim)),
-            ]));
-
-            let gauge = Gauge::default()
-                .block(Block::default())
-                .gauge_style(Style::default().fg(gauge_color).bg(COLORS.bg_dark))
-                .percent((progress * 100.0) as u16);
-
-            let workflow_info_widget =
-                Paragraph::new(workflow_info).block(theme::block("Workflow Information"));
-
-            let gauge_area = Rect {
-                x: chunks[0].x + 2,
-                y: chunks[0].y + 4,
-                width: chunks[0].width.saturating_sub(4),
-                height: 1,
-            };
-
-            f.render_widget(workflow_info_widget, chunks[0]);
-            f.render_widget(gauge, gauge_area);
-
-            // Jobs list section
-            if execution.jobs.is_empty() {
-                let placeholder = Paragraph::new("No jobs have started execution yet...")
-                    .block(theme::block("Jobs"))
-                    .alignment(Alignment::Center);
-                f.render_widget(placeholder, chunks[1]);
-            } else {
-                let job_items: Vec<ListItem> = execution
-                    .jobs
-                    .iter()
-                    .map(|job| {
-                        let (status_symbol, status_style) = theme::job_status(&job.status);
-
-                        let total_steps = job.steps.len();
-                        let completed_steps = job
-                            .steps
-                            .iter()
-                            .filter(|s| {
-                                s.status == wrkflw_executor::StepStatus::Success
-                                    || s.status == wrkflw_executor::StepStatus::Failure
-                            })
-                            .count();
-
-                        let steps_info = format!("[{}/{}]", completed_steps, total_steps);
-
-                        ListItem::new(Line::from(vec![
-                            Span::styled(status_symbol, status_style),
-                            Span::raw(" "),
-                            Span::styled(
-                                &job.name,
-                                Style::default()
-                                    .fg(COLORS.text)
-                                    .add_modifier(Modifier::BOLD),
-                            ),
-                            Span::raw(" "),
-                            Span::styled(steps_info, theme::muted_style()),
-                        ]))
-                    })
-                    .collect();
-
-                let jobs_list = List::new(job_items)
-                    .block(theme::block("Jobs"))
-                    .highlight_style(theme::selected_style())
-                    .highlight_symbol(theme::symbols::SELECTED);
-
-                f.render_stateful_widget(jobs_list, chunks[1], &mut app.job_list_state);
-            }
-
-            // Execution info section
-            let mut execution_info = Vec::new();
-
-            execution_info.push(Line::from(vec![
-                Span::styled("Started: ", theme::label_style()),
-                Span::styled(
-                    execution.start_time.format("%Y-%m-%d %H:%M:%S").to_string(),
-                    Style::default().fg(COLORS.text),
-                ),
-            ]));
-
-            if let Some(end_time) = execution.end_time {
-                execution_info.push(Line::from(vec![
-                    Span::styled("Finished: ", theme::label_style()),
-                    Span::styled(
-                        end_time.format("%Y-%m-%d %H:%M:%S").to_string(),
-                        Style::default().fg(COLORS.text),
-                    ),
-                ]));
-
-                let duration = end_time.signed_duration_since(execution.start_time);
-                execution_info.push(Line::from(vec![
-                    Span::styled("Duration: ", theme::label_style()),
-                    Span::styled(
-                        format!(
-                            "{}m {}s",
-                            duration.num_minutes(),
-                            duration.num_seconds() % 60
-                        ),
-                        Style::default().fg(COLORS.text),
-                    ),
-                ]));
-            } else {
-                let current_time = chrono::Local::now();
-                let running_time = current_time.signed_duration_since(execution.start_time);
-                execution_info.push(Line::from(vec![
-                    Span::styled("Running for: ", theme::label_style()),
-                    Span::styled(
-                        format!(
-                            "{}m {}s",
-                            running_time.num_minutes(),
-                            running_time.num_seconds() % 60
-                        ),
-                        Style::default().fg(COLORS.text),
-                    ),
-                ]));
-            }
-
-            execution_info.push(Line::from(""));
-            execution_info.push(Line::from(vec![
-                Span::styled("Press ", theme::muted_style()),
-                Span::styled("Enter", theme::key_style()),
-                Span::styled(" to view job details", theme::muted_style()),
-            ]));
-
-            let info_widget =
-                Paragraph::new(execution_info).block(theme::block("Execution Information"));
-
-            f.render_widget(info_widget, chunks[2]);
+        let is_selected = i == app.job_list_state.selected().unwrap_or(0);
+        let row_style = if is_selected {
+            theme::selected_style()
         } else {
-            // No execution details
-            let workflow_info_widget =
-                Paragraph::new(workflow_info).block(theme::block("Workflow Information"));
+            Style::default()
+        };
+        let name_style = if job_exec.is_some() || active_name.as_deref() == Some(name) {
+            Style::default().fg(COLORS.text)
+        } else {
+            Style::default().fg(COLORS.text_muted)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(" ", row_style),
+            Span::styled(sym.to_string(), sym_style),
+            Span::raw(" "),
+            Span::styled(name.clone(), name_style.patch(row_style)),
+        ]));
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "no jobs in this workflow",
+            Style::default().fg(COLORS.text_muted),
+        )));
+    }
 
-            f.render_widget(workflow_info_widget, chunks[0]);
+    // Footer summary
+    let total = workflow.job_names.len();
+    let done = exec
+        .map(|e| {
+            e.jobs
+                .iter()
+                .filter(|j| matches!(j.status, JobStatus::Success | JobStatus::Skipped))
+                .count()
+        })
+        .unwrap_or(0);
+    let failed = exec
+        .map(|e| e.jobs.iter().filter(|j| matches!(j.status, JobStatus::Failure)).count())
+        .unwrap_or(0);
+    let pending = total.saturating_sub(done + failed);
 
-            let placeholder = Paragraph::new(vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "No execution data available.",
-                    Style::default()
-                        .fg(COLORS.warning)
-                        .add_modifier(Modifier::BOLD),
-                )),
-                Line::from(""),
-                Line::from(vec![
-                    Span::styled("Press ", theme::muted_style()),
-                    Span::styled("Enter", theme::key_style()),
-                    Span::styled(" to run this workflow.", theme::muted_style()),
-                ]),
-                Line::from(""),
-            ])
-            .block(theme::block("Jobs"))
-            .alignment(Alignment::Center);
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(format!("{}/{}", done, total), Style::default().fg(COLORS.success)),
+        Span::styled(" done · ", Style::default().fg(COLORS.text_muted)),
+        Span::styled(format!("{}", failed), Style::default().fg(COLORS.error)),
+        Span::styled(" failed · ", Style::default().fg(COLORS.text_muted)),
+        Span::styled(
+            format!("{}", pending),
+            Style::default().fg(COLORS.text_muted),
+        ),
+        Span::styled(" pending", Style::default().fg(COLORS.text_muted)),
+    ]));
 
-            f.render_widget(placeholder, chunks[1]);
+    f.render_widget(Paragraph::new(lines), inner_area);
+}
 
-            let info_widget = Paragraph::new(vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "No execution has been started.",
-                    Style::default().fg(COLORS.warning),
-                )),
-                Line::from(""),
-                Line::from(vec![
-                    Span::styled("Press ", theme::muted_style()),
-                    Span::styled("Enter", theme::key_style()),
-                    Span::styled(" in the Workflows tab to run, or ", theme::muted_style()),
-                    Span::styled("t", theme::key_style()),
-                    Span::styled(" to trigger on GitHub.", theme::muted_style()),
-                ]),
-            ])
-            .block(theme::block("Execution Information"))
-            .alignment(Alignment::Center);
+// ─── Steps pane (centre top) ──────────────────────────────────────
+fn render_steps_pane(f: &mut Frame<'_>, workflow: &crate::models::Workflow, area: Rect) {
+    let title = match active_job_execution(workflow) {
+        Some(j) => format!("Steps — {}", j.name),
+        None => "Steps".to_string(),
+    };
+    let block = theme::block(&title);
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
 
-            f.render_widget(info_widget, chunks[2]);
+    let job = match active_job_execution(workflow) {
+        Some(j) => j,
+        None => {
+            f.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    "no active job",
+                    Style::default().fg(COLORS.text_muted),
+                ))),
+                inner_area,
+            );
+            return;
         }
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, step) in job.steps.iter().enumerate() {
+        let (sym, sym_style) = theme::step_status(&step.status);
+        let name_style = match step.status {
+            StepStatus::Skipped => Style::default().fg(COLORS.text_muted),
+            _ => Style::default().fg(COLORS.text),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{:02} ", i + 1),
+                Style::default().fg(COLORS.text_muted),
+            ),
+            Span::styled(sym.to_string(), sym_style),
+            Span::raw("  "),
+            Span::styled(step.name.clone(), name_style),
+        ]));
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "no steps reported yet",
+            Style::default().fg(COLORS.text_muted),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), inner_area);
+}
+
+// ─── Live output pane (centre bottom) ─────────────────────────────
+fn render_live_output_pane(f: &mut Frame<'_>, app: &App, area: Rect) {
+    let block = theme::block_focused("Live output");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    if app.processed_logs.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "(no log lines yet — output will stream here)",
+                Style::default().fg(COLORS.text_muted),
+            ))),
+            inner_area,
+        );
+        return;
+    }
+
+    // Take the last N lines that fit in the pane.
+    let max_rows = inner_area.height as usize;
+    let start = app.processed_logs.len().saturating_sub(max_rows);
+    let lines: Vec<Line> = app.processed_logs[start..]
+        .iter()
+        .map(|entry| {
+            let mut spans: Vec<Span> = Vec::with_capacity(entry.content_spans.len() + 4);
+            spans.push(Span::styled(
+                entry.timestamp.clone(),
+                Style::default().fg(COLORS.text_muted),
+            ));
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                entry.log_type.clone(),
+                entry.log_style,
+            ));
+            spans.push(Span::raw(" "));
+            spans.extend(entry.content_spans.iter().cloned());
+            Line::from(spans)
+        })
+        .collect();
+
+    f.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }),
+        inner_area,
+    );
+}
+
+// ─── Mini DAG pane (right top) ────────────────────────────────────
+fn render_dag_pane(f: &mut Frame<'_>, app: &App, idx: usize, area: Rect) {
+    let block = theme::block("DAG");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let workflow = &app.workflows[idx];
+    let def = workflow.definition.as_deref();
+    let exec = workflow.execution_details.as_ref();
+    let active = active_job_name(workflow);
+
+    let state_of = |name: &str| -> dag::NodeState {
+        if let Some(e) = exec {
+            if let Some(j) = e.jobs.iter().find(|j| j.name == name) {
+                return match j.status {
+                    JobStatus::Success => dag::NodeState::Success,
+                    JobStatus::Failure => dag::NodeState::Failure,
+                    JobStatus::Skipped => dag::NodeState::Skipped,
+                };
+            }
+        }
+        if active.as_deref() == Some(name) {
+            dag::NodeState::Running
+        } else {
+            dag::NodeState::Pending
+        }
+    };
+
+    dag::render(f, inner_area, def, state_of, app.spinner_frame);
+}
+
+// ─── Timing pane (right bottom) ───────────────────────────────────
+fn render_timing_pane(f: &mut Frame<'_>, workflow: &crate::models::Workflow, area: Rect) {
+    let block = theme::block("Timing");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let exec = match workflow.execution_details.as_ref() {
+        Some(e) => e,
+        None => {
+            f.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    "no run yet",
+                    Style::default().fg(COLORS.text_muted),
+                ))),
+                inner_area,
+            );
+            return;
+        }
+    };
+
+    let labels: Vec<String> = exec
+        .jobs
+        .iter()
+        .map(|j| match j.status {
+            JobStatus::Success => "ok".to_string(),
+            JobStatus::Failure => "fail".to_string(),
+            JobStatus::Skipped => "skip".to_string(),
+        })
+        .collect();
+
+    let rows: Vec<TimingRow> = exec
+        .jobs
+        .iter()
+        .zip(labels.iter())
+        .map(|(j, label)| TimingRow {
+            name: j.name.as_str(),
+            status: Some(j.status.clone()),
+            label: label.as_str(),
+        })
+        .collect();
+
+    timing::render(f, inner_area, &rows);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────
+fn active_job_execution(
+    workflow: &crate::models::Workflow,
+) -> Option<&crate::models::JobExecution> {
+    let exec = workflow.execution_details.as_ref()?;
+    if matches!(workflow.status, WorkflowStatus::Running) {
+        // Most-recent job is the one currently driving the run.
+        exec.jobs.last()
     } else {
-        // No workflow selected
-        let placeholder = Paragraph::new(vec![
+        // Otherwise prefer the failed job so the live output points at the
+        // interesting place; fall back to the last job.
+        exec.jobs
+            .iter()
+            .rfind(|j| matches!(j.status, JobStatus::Failure))
+            .or_else(|| exec.jobs.last())
+    }
+}
+
+fn active_job_name(workflow: &crate::models::Workflow) -> Option<String> {
+    if !matches!(workflow.status, WorkflowStatus::Running) {
+        return None;
+    }
+    let exec = workflow.execution_details.as_ref()?;
+    // The first job in `job_names` not yet present in `exec.jobs` is the one
+    // about to run; the last job in `exec.jobs` may still be in flight.
+    let executed: std::collections::HashSet<&str> =
+        exec.jobs.iter().map(|j| j.name.as_str()).collect();
+    workflow
+        .job_names
+        .iter()
+        .find(|n| !executed.contains(n.as_str()))
+        .cloned()
+        .or_else(|| exec.jobs.last().map(|j| j.name.clone()))
+}
+
+fn render_empty_state(f: &mut Frame<'_>, area: Rect) {
+    let block = theme::block("Run");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(
+        Paragraph::new(vec![
             Line::from(""),
             Line::from(Span::styled(
-                "No workflow execution data available.",
+                "No workflow execution yet.",
                 Style::default()
                     .fg(COLORS.warning)
                     .add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
             Line::from(vec![
-                Span::styled("Select workflows in the ", theme::muted_style()),
-                Span::styled("Workflows", Style::default().fg(COLORS.accent)),
-                Span::styled(" tab and press ", theme::muted_style()),
-                Span::styled("r", theme::key_style()),
-                Span::styled(" to run them.", theme::muted_style()),
-            ]),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled("Or press ", theme::muted_style()),
-                Span::styled("t", theme::key_style()),
-                Span::styled(" to trigger a workflow on GitHub.", theme::muted_style()),
+                Span::styled("Switch to ", Style::default().fg(COLORS.text_muted)),
+                Span::styled(
+                    "Workflows",
+                    Style::default().fg(COLORS.accent),
+                ),
+                Span::styled(" and press ", Style::default().fg(COLORS.text_muted)),
+                theme::key_chip("r"),
+                Span::styled(" to run, or ", Style::default().fg(COLORS.text_muted)),
+                theme::key_chip("t"),
+                Span::styled(" to trigger remotely.", Style::default().fg(COLORS.text_muted)),
             ]),
         ])
-        .block(theme::block("Execution"))
-        .alignment(Alignment::Center);
-
-        f.render_widget(placeholder, area);
-    }
+        .alignment(Alignment::Center),
+        inner_area,
+    );
 }

--- a/crates/ui/src/views/execution_tab.rs
+++ b/crates/ui/src/views/execution_tab.rs
@@ -158,8 +158,14 @@ fn render_jobs_pane(f: &mut Frame<'_>, app: &App, idx: usize, area: Rect) {
         let job_exec = exec.and_then(|e| e.jobs.iter().find(|j| j.name == *name));
         let (sym, sym_style) = match (job_exec, active_name.as_deref() == Some(name)) {
             (Some(j), _) => theme::job_status(&j.status),
-            (None, true) => (theme::spinner(app.spinner_frame), Style::default().fg(COLORS.info)),
-            (None, false) => (theme::symbols::NOT_STARTED, Style::default().fg(COLORS.text_muted)),
+            (None, true) => (
+                theme::spinner(app.spinner_frame),
+                Style::default().fg(COLORS.info),
+            ),
+            (None, false) => (
+                theme::symbols::NOT_STARTED,
+                Style::default().fg(COLORS.text_muted),
+            ),
         };
         let is_selected = i == app.job_list_state.selected().unwrap_or(0);
         let row_style = if is_selected {
@@ -197,13 +203,21 @@ fn render_jobs_pane(f: &mut Frame<'_>, app: &App, idx: usize, area: Rect) {
         })
         .unwrap_or(0);
     let failed = exec
-        .map(|e| e.jobs.iter().filter(|j| matches!(j.status, JobStatus::Failure)).count())
+        .map(|e| {
+            e.jobs
+                .iter()
+                .filter(|j| matches!(j.status, JobStatus::Failure))
+                .count()
+        })
         .unwrap_or(0);
     let pending = total.saturating_sub(done + failed);
 
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
-        Span::styled(format!("{}/{}", done, total), Style::default().fg(COLORS.success)),
+        Span::styled(
+            format!("{}/{}", done, total),
+            Style::default().fg(COLORS.success),
+        ),
         Span::styled(" done · ", Style::default().fg(COLORS.text_muted)),
         Span::styled(format!("{}", failed), Style::default().fg(COLORS.error)),
         Span::styled(" failed · ", Style::default().fg(COLORS.text_muted)),
@@ -296,20 +310,14 @@ fn render_live_output_pane(f: &mut Frame<'_>, app: &App, area: Rect) {
                 Style::default().fg(COLORS.text_muted),
             ));
             spans.push(Span::raw(" "));
-            spans.push(Span::styled(
-                entry.log_type.clone(),
-                entry.log_style,
-            ));
+            spans.push(Span::styled(entry.log_type.clone(), entry.log_style));
             spans.push(Span::raw(" "));
             spans.extend(entry.content_spans.iter().cloned());
             Line::from(spans)
         })
         .collect();
 
-    f.render_widget(
-        Paragraph::new(lines).wrap(Wrap { trim: false }),
-        inner_area,
-    );
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner_area);
 }
 
 // ─── Mini DAG pane (right top) ────────────────────────────────────
@@ -438,15 +446,15 @@ fn render_empty_state(f: &mut Frame<'_>, area: Rect) {
             Line::from(""),
             Line::from(vec![
                 Span::styled("Switch to ", Style::default().fg(COLORS.text_muted)),
-                Span::styled(
-                    "Workflows",
-                    Style::default().fg(COLORS.accent),
-                ),
+                Span::styled("Workflows", Style::default().fg(COLORS.accent)),
                 Span::styled(" and press ", Style::default().fg(COLORS.text_muted)),
                 theme::key_chip("r"),
                 Span::styled(" to run, or ", Style::default().fg(COLORS.text_muted)),
                 theme::key_chip("t"),
-                Span::styled(" to trigger remotely.", Style::default().fg(COLORS.text_muted)),
+                Span::styled(
+                    " to trigger remotely.",
+                    Style::default().fg(COLORS.text_muted),
+                ),
             ]),
         ])
         .alignment(Alignment::Center),

--- a/crates/ui/src/views/job_detail.rs
+++ b/crates/ui/src/views/job_detail.rs
@@ -1,151 +1,458 @@
-// Job detail view rendering
+// Step inspector — tabbed sub-view inside the Execution tab.
+//
+// Mirrors `StepDetailScreen` from screens-core.jsx of the design handoff:
+// breadcrumb header, sub-tabs for Output / Env / Files / Matrix / Timeline.
+// Env/Files don't have backing data today so we render honest placeholders;
+// Output reuses each step's stdout, Matrix reads `Job.strategy`, and Timeline
+// reuses the timing chart with one row per step.
+
 use crate::app::App;
-use crate::theme::{self, COLORS};
+use crate::components::timing::{self, TimingRow};
+use crate::theme::{self, BadgeKind, COLORS};
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Paragraph, Row, Table, Wrap},
+    widgets::{Paragraph, Wrap},
     Frame,
 };
+use wrkflw_executor::{JobStatus, StepStatus};
 
-// Render the job detail view
+const TABS: [&str; 5] = ["Output", "Env", "Files", "Matrix", "Timeline"];
+
 pub fn render_job_detail_view(f: &mut Frame<'_>, app: &mut App, area: Rect) {
-    let current_workflow_idx = app
+    let workflow_idx = app
         .current_execution
         .or_else(|| app.workflow_list_state.selected())
         .filter(|&idx| idx < app.workflows.len());
 
-    if let Some(workflow_idx) = current_workflow_idx {
-        if let Some(execution) = &app.workflows[workflow_idx].execution_details {
-            if let Some(job_idx) = app.job_list_state.selected() {
-                if job_idx < execution.jobs.len() {
-                    let job = &execution.jobs[job_idx];
-                    let workflow_name = &app.workflows[workflow_idx].name;
+    let Some(workflow_idx) = workflow_idx else {
+        return;
+    };
+    let workflow = &app.workflows[workflow_idx];
+    let Some(execution) = workflow.execution_details.as_ref() else {
+        return;
+    };
+    let Some(job_idx) = app.job_list_state.selected() else {
+        return;
+    };
+    if job_idx >= execution.jobs.len() {
+        return;
+    }
+    let job = &execution.jobs[job_idx];
 
-                    let chunks = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints(
-                            [
-                                Constraint::Length(4), // Job title + breadcrumb
-                                Constraint::Min(5),    // Steps table
-                                Constraint::Length(8), // Step details
-                            ]
-                            .as_ref(),
-                        )
-                        .margin(1)
-                        .split(area);
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // breadcrumb
+            Constraint::Length(2), // tabs
+            Constraint::Min(0),    // body
+        ])
+        .margin(1)
+        .split(area);
 
-                    // Job title with breadcrumb
-                    let (status_symbol, status_style) = theme::job_status(&job.status);
-                    let status_text = match job.status {
-                        wrkflw_executor::JobStatus::Success => "Success",
-                        wrkflw_executor::JobStatus::Failure => "Failed",
-                        wrkflw_executor::JobStatus::Skipped => "Skipped",
-                    };
+    render_breadcrumb(f, &workflow.name, job, outer[0]);
+    render_tab_strip(f, app.step_inspector_tab, outer[1]);
 
-                    let job_title = Paragraph::new(vec![
-                        // Breadcrumb
-                        Line::from(vec![
-                            Span::styled(workflow_name, theme::muted_style()),
-                            Span::styled(
-                                format!(" {} ", theme::symbols::ARROW),
-                                theme::muted_style(),
-                            ),
-                            Span::styled(
-                                &job.name,
-                                Style::default()
-                                    .fg(COLORS.text)
-                                    .add_modifier(Modifier::BOLD),
-                            ),
-                        ]),
-                        Line::from(vec![
-                            Span::styled(status_symbol, status_style),
-                            Span::raw(" "),
-                            Span::styled(status_text, status_style),
-                            Span::styled(
-                                format!("  {} steps", job.steps.len()),
-                                theme::muted_style(),
-                            ),
-                        ]),
-                    ])
-                    .block(theme::block("Job Details"));
+    let selected_step_idx = app
+        .step_table_state
+        .selected()
+        .filter(|&i| i < job.steps.len());
 
-                    f.render_widget(job_title, chunks[0]);
+    match app.step_inspector_tab {
+        0 => render_output_pane(f, job, selected_step_idx, outer[2]),
+        1 => render_env_pane(f, outer[2]),
+        2 => render_files_pane(f, outer[2]),
+        3 => render_matrix_pane(f, workflow, &job.name, outer[2]),
+        4 => render_timeline_pane(f, job, outer[2]),
+        _ => {}
+    }
+}
 
-                    // Steps section
-                    let header_cells = ["Status", "Step Name"]
-                        .iter()
-                        .map(|h| ratatui::widgets::Cell::from(*h).style(theme::header_style()));
+fn render_breadcrumb(
+    f: &mut Frame<'_>,
+    workflow_name: &str,
+    job: &crate::models::JobExecution,
+    area: Rect,
+) {
+    let (sym, sym_style) = theme::job_status(&job.status);
+    let status_text = match job.status {
+        JobStatus::Success => ("success", BadgeKind::Success),
+        JobStatus::Failure => ("failed", BadgeKind::Error),
+        JobStatus::Skipped => ("skipped", BadgeKind::Warning),
+    };
 
-                    let header = Row::new(header_cells).height(1);
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(20)])
+        .split(area);
 
-                    let rows = job.steps.iter().map(|step| {
-                        let (status_symbol, status_style) = theme::step_status(&step.status);
+    let left = Paragraph::new(Line::from(vec![
+        Span::styled(
+            workflow_name.to_string(),
+            Style::default().fg(COLORS.text_muted),
+        ),
+        Span::styled(" / ", Style::default().fg(COLORS.text_muted)),
+        Span::styled(sym.to_string(), sym_style),
+        Span::raw(" "),
+        Span::styled(
+            job.name.clone(),
+            Style::default()
+                .fg(COLORS.text)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("   ({} steps)", job.steps.len()),
+            Style::default().fg(COLORS.text_muted),
+        ),
+    ]))
+    .alignment(Alignment::Left);
+    f.render_widget(left, chunks[0]);
 
-                        Row::new(vec![
-                            ratatui::widgets::Cell::from(status_symbol).style(status_style),
-                            ratatui::widgets::Cell::from(step.name.clone())
-                                .style(Style::default().fg(COLORS.text)),
-                        ])
-                    });
+    let right = Paragraph::new(Line::from(vec![theme::badge_outline(
+        status_text.0,
+        status_text.1,
+    )]))
+    .alignment(Alignment::Right);
+    f.render_widget(right, chunks[1]);
+}
 
-                    let widths = [
-                        Constraint::Length(4),      // Status icon column
-                        Constraint::Percentage(92), // Name column
-                    ];
-                    let steps_table = Table::new(rows, widths)
-                        .header(header)
-                        .block(theme::block("Steps"))
-                        .highlight_style(theme::selected_style())
-                        .highlight_symbol(theme::symbols::SELECTED);
-
-                    f.render_stateful_widget(steps_table, chunks[1], &mut app.step_table_state);
-
-                    // Step detail section
-                    if let Some(step_idx) = app.step_table_state.selected() {
-                        if step_idx < job.steps.len() {
-                            let step = &job.steps[step_idx];
-
-                            let (step_symbol, step_style) = theme::step_status(&step.status);
-                            let status_text = match step.status {
-                                wrkflw_executor::StepStatus::Success => "Success",
-                                wrkflw_executor::StepStatus::Failure => "Failed",
-                                wrkflw_executor::StepStatus::Skipped => "Skipped",
-                            };
-
-                            let mut output_text = step.output.clone();
-                            if output_text.len() > 5000 {
-                                output_text =
-                                    format!("{}\u{2026} [truncated]", &output_text[..5000]);
-                            }
-
-                            let step_detail = Paragraph::new(vec![
-                                Line::from(vec![
-                                    Span::styled(step_symbol, step_style),
-                                    Span::raw(" "),
-                                    Span::styled(
-                                        step.name.clone(),
-                                        Style::default()
-                                            .fg(COLORS.text)
-                                            .add_modifier(Modifier::BOLD),
-                                    ),
-                                    Span::styled(format!(" ({})", status_text), step_style),
-                                ]),
-                                Line::from(""),
-                                Line::from(Span::styled(
-                                    output_text,
-                                    Style::default().fg(COLORS.text_dim),
-                                )),
-                            ])
-                            .block(theme::block("Step Output"))
-                            .wrap(Wrap { trim: false });
-
-                            f.render_widget(step_detail, chunks[2]);
-                        }
-                    }
-                }
-            }
+fn render_tab_strip(f: &mut Frame<'_>, active: usize, area: Rect) {
+    let mut spans: Vec<Span> = Vec::with_capacity(TABS.len() * 3);
+    for (i, label) in TABS.iter().enumerate() {
+        let is_active = i == active;
+        spans.push(Span::styled(
+            format!(" {} ", label),
+            if is_active {
+                Style::default()
+                    .fg(COLORS.accent)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                Style::default().fg(COLORS.text_dim)
+            },
+        ));
+        if i + 1 < TABS.len() {
+            spans.push(Span::styled(
+                "·",
+                Style::default().fg(COLORS.text_muted),
+            ));
         }
     }
+    spans.push(Span::raw("  "));
+    spans.push(theme::key_chip("Tab"));
+    spans.push(Span::styled(
+        " switch  ",
+        Style::default().fg(COLORS.text_muted),
+    ));
+
+    f.render_widget(
+        Paragraph::new(Line::from(spans)).alignment(Alignment::Left),
+        area,
+    );
+}
+
+// ─── Output pane (default) ────────────────────────────────────────
+fn render_output_pane(
+    f: &mut Frame<'_>,
+    job: &crate::models::JobExecution,
+    selected_step: Option<usize>,
+    area: Rect,
+) {
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(34), Constraint::Min(0)])
+        .split(area);
+
+    render_steps_list(f, job, selected_step, cols[0]);
+    render_step_stdout(f, job, selected_step, cols[1]);
+}
+
+fn render_steps_list(
+    f: &mut Frame<'_>,
+    job: &crate::models::JobExecution,
+    selected: Option<usize>,
+    area: Rect,
+) {
+    let block = theme::block("Steps");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, step) in job.steps.iter().enumerate() {
+        let (sym, sym_style) = theme::step_status(&step.status);
+        let highlighted = selected == Some(i);
+        let row_style = if highlighted {
+            theme::selected_style()
+        } else {
+            Style::default()
+        };
+        let name_style = match step.status {
+            StepStatus::Skipped => Style::default().fg(COLORS.text_muted),
+            _ => Style::default().fg(COLORS.text),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{:02} ", i + 1),
+                Style::default().fg(COLORS.text_muted).patch(row_style),
+            ),
+            Span::styled(sym.to_string(), sym_style),
+            Span::raw(" "),
+            Span::styled(step.name.clone(), name_style.patch(row_style)),
+        ]));
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "no steps",
+            Style::default().fg(COLORS.text_muted),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), inner_area);
+}
+
+fn render_step_stdout(
+    f: &mut Frame<'_>,
+    job: &crate::models::JobExecution,
+    selected: Option<usize>,
+    area: Rect,
+) {
+    let title = match selected.and_then(|i| job.steps.get(i)) {
+        Some(s) => format!("stdout — {}", s.name),
+        None => "stdout".to_string(),
+    };
+    let block = theme::block_focused(&title);
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(step) = selected.and_then(|i| job.steps.get(i)) else {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "(select a step on the left)",
+                Style::default().fg(COLORS.text_muted),
+            ))),
+            inner_area,
+        );
+        return;
+    };
+
+    if step.output.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "(no output captured for this step)",
+                Style::default().fg(COLORS.text_muted),
+            ))),
+            inner_area,
+        );
+        return;
+    }
+
+    let mut output = step.output.clone();
+    if output.len() > 8000 {
+        output = format!("{}…[truncated]", &output[..8000]);
+    }
+    let lines: Vec<Line> = output
+        .split('\n')
+        .map(|l| Line::from(Span::styled(l.to_string(), Style::default().fg(COLORS.text_dim))))
+        .collect();
+
+    f.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }),
+        inner_area,
+    );
+}
+
+// ─── Env pane (placeholder) ───────────────────────────────────────
+fn render_env_pane(f: &mut Frame<'_>, area: Rect) {
+    let block = theme::block("Process environment");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "Per-step environment capture is not yet plumbed.",
+            Style::default()
+                .fg(COLORS.warning)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "When the executor starts snapshotting `cmd.env` per step, the",
+            Style::default().fg(COLORS.text_dim),
+        )),
+        Line::from(Span::styled(
+            "env table will appear here with secret-masking on by default.",
+            Style::default().fg(COLORS.text_dim),
+        )),
+    ];
+    f.render_widget(
+        Paragraph::new(lines).alignment(Alignment::Center),
+        inner_area,
+    );
+}
+
+// ─── Files pane (placeholder) ─────────────────────────────────────
+fn render_files_pane(f: &mut Frame<'_>, area: Rect) {
+    let block = theme::block("Workspace changes");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "Workspace diff per step is not yet captured.",
+            Style::default()
+                .fg(COLORS.warning)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Will list new/modified artifacts under the job workspace once the",
+            Style::default().fg(COLORS.text_dim),
+        )),
+        Line::from(Span::styled(
+            "runtime exposes a watched-fs handle.",
+            Style::default().fg(COLORS.text_dim),
+        )),
+    ];
+    f.render_widget(
+        Paragraph::new(lines).alignment(Alignment::Center),
+        inner_area,
+    );
+}
+
+// ─── Matrix pane ──────────────────────────────────────────────────
+fn render_matrix_pane(
+    f: &mut Frame<'_>,
+    workflow: &crate::models::Workflow,
+    job_name: &str,
+    area: Rect,
+) {
+    let block = theme::block("Matrix");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let strategy = workflow
+        .definition
+        .as_ref()
+        .and_then(|d| d.jobs.get(job_name))
+        .and_then(|j| j.strategy.as_ref());
+
+    let Some(strategy) = strategy else {
+        let lines = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("`{}` is not a matrix job.", job_name),
+                Style::default().fg(COLORS.text_dim),
+            )),
+        ];
+        f.render_widget(
+            Paragraph::new(lines).alignment(Alignment::Center),
+            inner_area,
+        );
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![Span::styled(
+        "AXES",
+        Style::default()
+            .fg(COLORS.highlight)
+            .add_modifier(Modifier::BOLD),
+    )]));
+
+    let Some(matrix) = strategy.matrix.as_ref() else {
+        lines.push(Line::from(Span::styled(
+            "(matrix strategy with no axes)",
+            Style::default().fg(COLORS.text_muted),
+        )));
+        f.render_widget(Paragraph::new(lines), inner_area);
+        return;
+    };
+
+    for (name, value) in &matrix.parameters {
+        let values: Vec<String> = match value.as_sequence() {
+            Some(seq) => seq
+                .iter()
+                .filter_map(|n| {
+                    n.as_str()
+                        .map(|s| s.to_string())
+                        .or_else(|| n.as_i64().map(|i| i.to_string()))
+                        .or_else(|| n.as_f64().map(|f| f.to_string()))
+                })
+                .collect(),
+            None => vec![format!("{:?}", value)],
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {}: ", name), Style::default().fg(COLORS.accent)),
+            Span::styled(values.join(", "), Style::default().fg(COLORS.text)),
+        ]));
+    }
+
+    let mut chips: Vec<Span> = Vec::new();
+    if let Some(max) = strategy.max_parallel.or(matrix.max_parallel) {
+        chips.push(theme::badge_outline(
+            format!("max-parallel: {}", max),
+            BadgeKind::Dim,
+        ));
+        chips.push(Span::raw(" "));
+    }
+    let fail_fast = strategy.fail_fast.or(matrix.fail_fast).unwrap_or(true);
+    if !fail_fast {
+        chips.push(theme::badge_outline("fail-fast: false", BadgeKind::Warning));
+    }
+    if !chips.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(chips));
+    }
+    if !matrix.include.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![Span::styled(
+            format!("INCLUDE ({})", matrix.include.len()),
+            Style::default()
+                .fg(COLORS.highlight)
+                .add_modifier(Modifier::BOLD),
+        )]));
+    }
+    if !matrix.exclude.is_empty() {
+        lines.push(Line::from(vec![Span::styled(
+            format!("EXCLUDE ({})", matrix.exclude.len()),
+            Style::default()
+                .fg(COLORS.highlight)
+                .add_modifier(Modifier::BOLD),
+        )]));
+    }
+
+    f.render_widget(Paragraph::new(lines), inner_area);
+}
+
+// ─── Timeline pane (uses timing component) ────────────────────────
+fn render_timeline_pane(f: &mut Frame<'_>, job: &crate::models::JobExecution, area: Rect) {
+    let block = theme::block("Step timeline");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let labels: Vec<String> = job
+        .steps
+        .iter()
+        .map(|s| match s.status {
+            StepStatus::Success => "ok".to_string(),
+            StepStatus::Failure => "fail".to_string(),
+            StepStatus::Skipped => "skip".to_string(),
+        })
+        .collect();
+
+    let rows: Vec<TimingRow> = job
+        .steps
+        .iter()
+        .zip(labels.iter())
+        .map(|(s, label)| TimingRow {
+            name: s.name.as_str(),
+            status: match s.status {
+                StepStatus::Success => Some(JobStatus::Success),
+                StepStatus::Failure => Some(JobStatus::Failure),
+                StepStatus::Skipped => Some(JobStatus::Skipped),
+            },
+            label: label.as_str(),
+        })
+        .collect();
+
+    timing::render(f, inner_area, &rows);
 }

--- a/crates/ui/src/views/job_detail.rs
+++ b/crates/ui/src/views/job_detail.rs
@@ -132,10 +132,7 @@ fn render_tab_strip(f: &mut Frame<'_>, active: usize, area: Rect) {
             },
         ));
         if i + 1 < TABS.len() {
-            spans.push(Span::styled(
-                "·",
-                Style::default().fg(COLORS.text_muted),
-            ));
+            spans.push(Span::styled("·", Style::default().fg(COLORS.text_muted)));
         }
     }
     spans.push(Span::raw("  "));
@@ -251,13 +248,15 @@ fn render_step_stdout(
     }
     let lines: Vec<Line> = output
         .split('\n')
-        .map(|l| Line::from(Span::styled(l.to_string(), Style::default().fg(COLORS.text_dim))))
+        .map(|l| {
+            Line::from(Span::styled(
+                l.to_string(),
+                Style::default().fg(COLORS.text_dim),
+            ))
+        })
         .collect();
 
-    f.render_widget(
-        Paragraph::new(lines).wrap(Wrap { trim: false }),
-        inner_area,
-    );
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner_area);
 }
 
 // ─── Env pane (placeholder) ───────────────────────────────────────

--- a/crates/ui/src/views/mod.rs
+++ b/crates/ui/src/views/mod.rs
@@ -25,9 +25,9 @@ pub fn render_ui(f: &mut Frame<'_>, app: &mut App) {
         .direction(ratatui::layout::Direction::Vertical)
         .constraints(
             [
-                ratatui::layout::Constraint::Length(3), // Title bar and tabs
+                ratatui::layout::Constraint::Length(1), // Title bar and tabs
                 ratatui::layout::Constraint::Min(5),    // Main content
-                ratatui::layout::Constraint::Length(2), // Status bar
+                ratatui::layout::Constraint::Length(1), // Status bar
             ]
             .as_ref(),
         )

--- a/crates/ui/src/views/status_bar.rs
+++ b/crates/ui/src/views/status_bar.rs
@@ -1,9 +1,9 @@
-// Status bar rendering
+// Status bar — left-aligned key chips, right-aligned runtime + meta.
 use crate::app::App;
 use crate::models::StatusSeverity;
-use crate::theme::{self, COLORS};
+use crate::theme::{self, BadgeKind, COLORS};
 use ratatui::{
-    layout::{Alignment, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
@@ -11,9 +11,7 @@ use ratatui::{
 };
 use wrkflw_executor::RuntimeType;
 
-// Render the status bar
 pub fn render_status_bar(f: &mut Frame<'_>, app: &App, area: Rect) {
-    // If we have a status message, show it as a toast
     if let Some(message) = &app.status_message {
         let bg = match app.status_message_severity {
             StatusSeverity::Success => COLORS.success,
@@ -21,144 +19,137 @@ pub fn render_status_bar(f: &mut Frame<'_>, app: &App, area: Rect) {
             StatusSeverity::Warning => COLORS.warning,
             StatusSeverity::Error => COLORS.error,
         };
-
-        let status_message = Paragraph::new(Line::from(vec![Span::styled(
+        let toast = Paragraph::new(Line::from(vec![Span::styled(
             format!(" {} ", message),
             Style::default()
                 .bg(bg)
-                .fg(COLORS.text)
+                .fg(COLORS.bg_dark)
                 .add_modifier(Modifier::BOLD),
         )]))
-        .alignment(Alignment::Center);
-
-        f.render_widget(status_message, area);
+        .alignment(Alignment::Center)
+        .style(Style::default().bg(COLORS.bg_bar));
+        f.render_widget(toast, area);
         return;
     }
 
-    // Normal status bar
-    let mut status_items = vec![];
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(48)])
+        .split(area);
 
-    // Runtime mode badge
-    status_items.push(theme::badge(
-        app.runtime_type_name(),
-        match app.runtime_type {
-            RuntimeType::Docker => COLORS.runtime_docker,
-            RuntimeType::Podman => COLORS.runtime_podman,
-            RuntimeType::SecureEmulation => COLORS.runtime_secure,
-            RuntimeType::Emulation => COLORS.runtime_emulation,
-        },
-        COLORS.text,
-    ));
-
-    // Container runtime status (uses cached availability from App state)
-    match app.runtime_type {
-        RuntimeType::Docker => {
-            status_items.push(Span::raw(" "));
-            status_items.push(theme::badge(
-                if app.runtime_available {
-                    "Docker: Connected"
-                } else {
-                    "Docker: Unavailable"
-                },
-                if app.runtime_available {
-                    COLORS.success
-                } else {
-                    COLORS.error
-                },
-                COLORS.text,
-            ));
+    // Left: key chips
+    let mut left: Vec<Span> = Vec::new();
+    for (i, (key, desc)) in context_hints(app).into_iter().enumerate() {
+        if i > 0 {
+            left.push(Span::raw("  "));
         }
-        RuntimeType::Podman => {
-            status_items.push(Span::raw(" "));
-            status_items.push(theme::badge(
-                if app.runtime_available {
-                    "Podman: Connected"
-                } else {
-                    "Podman: Unavailable"
-                },
-                if app.runtime_available {
-                    COLORS.success
-                } else {
-                    COLORS.error
-                },
-                COLORS.text,
-            ));
-        }
-        RuntimeType::SecureEmulation => {
-            status_items.push(Span::raw(" "));
-            status_items.push(Span::styled(
-                format!(" {}SECURE ", theme::symbols::LOCK),
-                Style::default().bg(COLORS.runtime_secure).fg(COLORS.text),
-            ));
-        }
-        RuntimeType::Emulation => {}
+        left.push(theme::key_chip(key));
+        left.push(Span::styled(format!(" {}", desc), theme::hint_style()));
     }
+    let left_p = Paragraph::new(Line::from(left))
+        .style(Style::default().bg(COLORS.bg_bar))
+        .alignment(Alignment::Left);
+    f.render_widget(left_p, chunks[0]);
 
-    // Validation/execution mode badge
-    status_items.push(Span::raw(" "));
+    // Right: validation chip + runtime badge
+    let mut right: Vec<Span> = Vec::new();
+
     if app.validation_mode {
-        status_items.push(theme::badge(
-            "Validation",
-            COLORS.warning,
-            ratatui::style::Color::Black,
-        ));
+        right.push(theme::badge_outline("validation", BadgeKind::Warning));
     } else {
-        status_items.push(theme::badge(
-            "Execution",
-            COLORS.success,
-            ratatui::style::Color::Black,
-        ));
+        right.push(theme::badge_outline("execution", BadgeKind::Success));
     }
-
-    // Separator
-    status_items.push(Span::styled(
-        format!(" {} ", theme::symbols::SEPARATOR),
+    right.push(Span::raw(" "));
+    let runtime_badge_kind = match app.runtime_type {
+        RuntimeType::Docker => BadgeKind::Docker,
+        RuntimeType::Podman => BadgeKind::Podman,
+        RuntimeType::SecureEmulation => BadgeKind::Secure,
+        RuntimeType::Emulation => BadgeKind::Emulation,
+    };
+    right.push(theme::badge_solid(
+        app.runtime_type_name(),
+        runtime_badge_kind,
+    ));
+    right.push(Span::raw(" "));
+    let avail_color = if app.runtime_available {
+        COLORS.success
+    } else {
+        COLORS.text_muted
+    };
+    right.push(Span::styled(
+        if app.runtime_available { "●" } else { "○" }.to_string(),
+        Style::default().fg(avail_color),
+    ));
+    right.push(Span::raw(" "));
+    right.push(Span::styled(
+        format!("{} workflows", app.workflows.len()),
         Style::default().fg(COLORS.text_muted),
     ));
 
-    // Context-specific help
-    let help_text = build_context_help(app);
-    status_items.push(Span::styled(help_text, theme::hint_style()));
-
-    let status_bar = Paragraph::new(Line::from(status_items))
+    let right_p = Paragraph::new(Line::from(right))
         .style(Style::default().bg(COLORS.bg_bar))
-        .alignment(Alignment::Left);
-
-    f.render_widget(status_bar, area);
+        .alignment(Alignment::Right);
+    f.render_widget(right_p, chunks[1]);
 }
 
-fn build_context_help(app: &App) -> String {
+fn context_hints(app: &App) -> Vec<(&'static str, &'static str)> {
     match app.selected_tab {
         0 => {
             if app.job_selection_mode {
-                "Enter run \u{2502} a all \u{2502} Esc back".to_string()
+                vec![
+                    ("Enter", "run"),
+                    ("a", "all"),
+                    ("Esc", "back"),
+                    ("?", "help"),
+                ]
             } else if app.diff_filter_active {
-                "Space toggle \u{2502} Enter run \u{2502} r queue \u{2502} t trig \u{2502} d diff:ON \u{2502} ? help \u{2502} q quit".to_string()
+                vec![
+                    ("↑↓", "navigate"),
+                    ("Space", "select"),
+                    ("Enter", "run"),
+                    ("r", "queue"),
+                    ("t", "trigger"),
+                    ("d", "diff:ON"),
+                    ("?", "help"),
+                ]
             } else {
-                "Space toggle \u{2502} Enter run \u{2502} r queue \u{2502} t trig \u{2502} d diff \u{2502} ? help \u{2502} q quit".to_string()
+                vec![
+                    ("↑↓", "navigate"),
+                    ("Space", "select"),
+                    ("Enter", "run"),
+                    ("r", "queue"),
+                    ("t", "trigger"),
+                    ("d", "diff"),
+                    ("?", "help"),
+                ]
             }
         }
         1 => {
             if app.detailed_view {
-                "Esc back \u{2502} \u{2191}\u{2193} steps \u{2502} ? help \u{2502} q quit"
-                    .to_string()
+                vec![
+                    ("Tab", "switch pane"),
+                    ("↑↓", "steps"),
+                    ("Esc", "back"),
+                    ("?", "help"),
+                ]
             } else {
-                "Enter details \u{2502} \u{2191}\u{2193} jobs \u{2502} ? help \u{2502} q quit"
-                    .to_string()
+                vec![
+                    ("j/k", "move"),
+                    ("Enter", "inspect"),
+                    ("/", "search"),
+                    ("p", "pause"),
+                    ("?", "help"),
+                ]
             }
         }
-        2 => {
-            let log_count = app.logs.len() + wrkflw_logging::get_logs().len();
-            if log_count > 0 {
-                format!(
-                    "{} logs \u{2502} \u{2191}\u{2193} scroll \u{2502} s search \u{2502} f filter \u{2502} ? help \u{2502} q quit",
-                    log_count
-                )
-            } else {
-                "No logs \u{2502} ? help \u{2502} q quit".to_string()
-            }
-        }
-        3 => "\u{2191}\u{2193} scroll \u{2502} ? close \u{2502} q quit".to_string(),
-        _ => String::new(),
+        2 => vec![
+            ("↑↓", "scroll"),
+            ("s", "search"),
+            ("f", "filter"),
+            ("?", "help"),
+            ("q", "quit"),
+        ],
+        3 => vec![("↑↓", "scroll"), ("?", "close"), ("q", "quit")],
+        _ => vec![],
     }
 }

--- a/crates/ui/src/views/title_bar.rs
+++ b/crates/ui/src/views/title_bar.rs
@@ -39,10 +39,7 @@ pub fn render_title_bar(f: &mut Frame<'_>, app: &App, area: Rect) {
 
     // ─── Tabs ─────────────────────────────────────────────────
     let mut tab_spans: Vec<Span> = Vec::with_capacity(TAB_LABELS.len() * 4);
-    tab_spans.push(Span::styled(
-        " │ ",
-        Style::default().fg(COLORS.border),
-    ));
+    tab_spans.push(Span::styled(" │ ", Style::default().fg(COLORS.border)));
     for (i, label) in TAB_LABELS.iter().enumerate() {
         let active = i == app.selected_tab;
         tab_spans.push(Span::styled(

--- a/crates/ui/src/views/title_bar.rs
+++ b/crates/ui/src/views/title_bar.rs
@@ -1,56 +1,115 @@
-// Title bar rendering
+// Title bar — brand mark, numbered tabs, right-side LIVE + runtime indicator.
 use crate::app::App;
-use crate::theme::{self, COLORS};
+use crate::models::WorkflowStatus;
+use crate::theme::{self, BadgeKind, COLORS};
 use ratatui::{
-    layout::{Alignment, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Tabs},
+    widgets::Paragraph,
     Frame,
 };
+use wrkflw_executor::RuntimeType;
 
-// Render the title bar with tabs
+const TAB_LABELS: [&str; 4] = ["Workflows", "Execution", "Logs", "Help"];
+
 pub fn render_title_bar(f: &mut Frame<'_>, app: &App, area: Rect) {
-    let tab_labels = [
-        "1\u{00B7}Workflows",
-        "2\u{00B7}Execution",
-        "3\u{00B7}Logs",
-        "4\u{00B7}Help",
-    ];
-    let tab_lines: Vec<Line> = tab_labels
-        .iter()
-        .enumerate()
-        .map(|(i, t)| {
-            let style = if i == app.selected_tab {
-                Style::default()
-                    .fg(COLORS.highlight)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(COLORS.text_dim)
-            };
-            Line::from(Span::styled(*t, style))
-        })
-        .collect();
-    let tabs = Tabs::new(tab_lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(COLORS.border))
-                .title(Span::styled(" wrkflw ", theme::brand_style()))
-                .title_alignment(Alignment::Center),
-        )
-        .highlight_style(
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(14), // brand
+            Constraint::Min(0),     // tabs
+            Constraint::Length(34), // right indicators
+        ])
+        .split(area);
+
+    // ─── Brand ────────────────────────────────────────────────
+    let brand = Paragraph::new(Line::from(vec![
+        Span::styled(" w∿w ", Style::default().fg(COLORS.accent)),
+        Span::styled(
+            "wrkflw",
             Style::default()
-                .bg(COLORS.bg_selected)
-                .fg(COLORS.highlight)
+                .fg(COLORS.accent)
                 .add_modifier(Modifier::BOLD),
-        )
-        .select(app.selected_tab)
-        .divider(Span::styled(
-            theme::symbols::TAB_DIVIDER,
+        ),
+    ]))
+    .style(Style::default().bg(COLORS.bg_dark))
+    .alignment(Alignment::Left);
+    f.render_widget(brand, chunks[0]);
+
+    // ─── Tabs ─────────────────────────────────────────────────
+    let mut tab_spans: Vec<Span> = Vec::with_capacity(TAB_LABELS.len() * 4);
+    tab_spans.push(Span::styled(
+        " │ ",
+        Style::default().fg(COLORS.border),
+    ));
+    for (i, label) in TAB_LABELS.iter().enumerate() {
+        let active = i == app.selected_tab;
+        tab_spans.push(Span::styled(
+            format!("{}", i + 1),
             Style::default().fg(COLORS.text_muted),
         ));
+        tab_spans.push(Span::raw(" "));
+        tab_spans.push(Span::styled(
+            label.to_string(),
+            if active {
+                Style::default()
+                    .fg(COLORS.text)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                Style::default().fg(COLORS.text_dim)
+            },
+        ));
+        if i + 1 < TAB_LABELS.len() {
+            tab_spans.push(Span::raw("   "));
+        }
+    }
+    let tabs = Paragraph::new(Line::from(tab_spans))
+        .style(Style::default().bg(COLORS.bg_dark))
+        .alignment(Alignment::Left);
+    f.render_widget(tabs, chunks[1]);
 
-    f.render_widget(tabs, area);
+    // ─── Right: LIVE + runtime ────────────────────────────────
+    let mut right: Vec<Span> = Vec::new();
+    if let Some(elapsed) = live_elapsed(app) {
+        right.push(Span::styled("●", theme::pulse_style(app.spinner_frame)));
+        right.push(Span::raw(" "));
+        right.push(Span::styled(
+            "LIVE",
+            Style::default()
+                .fg(COLORS.text)
+                .add_modifier(Modifier::BOLD),
+        ));
+        right.push(Span::raw(" "));
+        right.push(Span::styled(elapsed, Style::default().fg(COLORS.text_dim)));
+        right.push(Span::raw("  "));
+    }
+    let runtime_kind = match app.runtime_type {
+        RuntimeType::Docker => BadgeKind::Docker,
+        RuntimeType::Podman => BadgeKind::Podman,
+        RuntimeType::SecureEmulation => BadgeKind::Secure,
+        RuntimeType::Emulation => BadgeKind::Emulation,
+    };
+    right.push(theme::badge_outline(app.runtime_type_name(), runtime_kind));
+    right.push(Span::raw(" "));
+
+    let right_p = Paragraph::new(Line::from(right))
+        .style(Style::default().bg(COLORS.bg_dark))
+        .alignment(Alignment::Right);
+    f.render_widget(right_p, chunks[2]);
+}
+
+/// Format elapsed time on the active execution as `mm:ss`. Returns `None`
+/// when no workflow is currently running.
+fn live_elapsed(app: &App) -> Option<String> {
+    let idx = app.current_execution?;
+    let wf = app.workflows.get(idx)?;
+    if !matches!(wf.status, WorkflowStatus::Running) {
+        return None;
+    }
+    let exec = wf.execution_details.as_ref()?;
+    let now = chrono::Local::now();
+    let elapsed = now.signed_duration_since(exec.start_time);
+    let total = elapsed.num_seconds().max(0);
+    Some(format!("{:02}:{:02}", total / 60, total % 60))
 }

--- a/crates/ui/src/views/workflows_tab.rs
+++ b/crates/ui/src/views/workflows_tab.rs
@@ -57,9 +57,7 @@ fn render_workflow_list(f: &mut Frame<'_>, app: &mut App, area: Rect) {
             let (status_symbol, status_style) =
                 theme::workflow_status_animated(&workflow.status, spinner_frame);
             let (trigger_symbol, trigger_style) = match &workflow.trigger_match {
-                Some(TriggerMatchStatus::Matched(_)) => {
-                    ("●", Style::default().fg(COLORS.success))
-                }
+                Some(TriggerMatchStatus::Matched(_)) => ("●", Style::default().fg(COLORS.success)),
                 Some(TriggerMatchStatus::Skipped(_)) => {
                     ("○", Style::default().fg(COLORS.text_muted))
                 }
@@ -94,8 +92,7 @@ fn render_workflow_list(f: &mut Frame<'_>, app: &mut App, area: Rect) {
                         .add_modifier(Modifier::BOLD),
                 ),
                 Cell::from(path_shortened).style(theme::muted_style()),
-                Cell::from(format!("{}", jobs_n))
-                    .style(Style::default().fg(COLORS.text_muted)),
+                Cell::from(format!("{}", jobs_n)).style(Style::default().fg(COLORS.text_muted)),
             ])
         })
         .collect();
@@ -202,11 +199,7 @@ fn render_preview(f: &mut Frame<'_>, app: &App, area: Rect) {
             ));
             badges.push(Span::raw(" "));
         }
-        let matrix_jobs = def
-            .jobs
-            .values()
-            .filter(|j| j.strategy.is_some())
-            .count();
+        let matrix_jobs = def.jobs.values().filter(|j| j.strategy.is_some()).count();
         if matrix_jobs > 0 {
             badges.push(theme::badge_outline(
                 format!("matrix: {}", matrix_jobs),
@@ -292,14 +285,18 @@ fn render_trigger_filter(f: &mut Frame<'_>, app: &App, area: Rect) {
                 Span::raw(" matches → "),
                 Span::styled(
                     format!("{}", matched),
-                    Style::default().fg(COLORS.text).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(COLORS.text)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::raw("   "),
                 Span::styled("○", Style::default().fg(COLORS.text_muted)),
                 Span::raw(" skipped → "),
                 Span::styled(
                     format!("{}", skipped),
-                    Style::default().fg(COLORS.text).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(COLORS.text)
+                        .add_modifier(Modifier::BOLD),
                 ),
             ]),
         ];
@@ -313,10 +310,7 @@ fn render_trigger_filter(f: &mut Frame<'_>, app: &App, area: Rect) {
             Line::from(vec![
                 Span::styled("press ", Style::default().fg(COLORS.text_dim)),
                 theme::key_chip("d"),
-                Span::styled(
-                    " to enable",
-                    Style::default().fg(COLORS.text_dim),
-                ),
+                Span::styled(" to enable", Style::default().fg(COLORS.text_dim)),
             ]),
         ];
         f.render_widget(Paragraph::new(lines), inner_area);

--- a/crates/ui/src/views/workflows_tab.rs
+++ b/crates/ui/src/views/workflows_tab.rs
@@ -1,40 +1,42 @@
-// Workflows tab rendering
+// Dashboard layout — workflows table on the left, preview / trigger filter /
+// quick actions on the right. Mirrors `DashboardScreen` from the design.
 use crate::app::App;
-use crate::models::TriggerMatchStatus;
-use crate::theme::{self, COLORS};
+use crate::models::{TriggerMatchStatus, WorkflowStatus};
+use crate::theme::{self, BadgeKind, COLORS};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
-    widgets::{Cell, Row, Table, TableState},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Cell, Paragraph, Row, Table, TableState, Wrap},
     Frame,
 };
 
-// Render the workflow list tab
 pub fn render_workflows_tab(f: &mut Frame<'_>, app: &mut App, area: Rect) {
     if app.job_selection_mode {
         render_job_selection(f, app, area);
-    } else {
-        render_workflow_list(f, app, area);
+        return;
     }
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(40), Constraint::Length(40)])
+        .margin(1)
+        .split(area);
+
+    render_workflow_list(f, app, chunks[0]);
+    render_right_column(f, app, chunks[1]);
 }
 
 fn render_workflow_list(f: &mut Frame<'_>, app: &mut App, area: Rect) {
     let selected_count = app.workflows.iter().filter(|w| w.selected).count();
-    // Surface the simulated event so users aren't confused when a
-    // pull_request-only workflow shows up as SKIPPED under the push-only
-    // diff filter.
     let diff_indicator = if app.diff_filter_active {
-        format!(" [DIFF: {}]", app.diff_filter_event)
+        format!("  [DIFF: {}]", app.diff_filter_event)
     } else {
         String::new()
     };
     let block_title = format!("Workflows ({} selected){}", selected_count, diff_indicator);
 
-    let header_cells = if app.diff_filter_active {
-        vec!["", "Status", "Trigger", "Workflow Name", "Path"]
-    } else {
-        vec!["", "Status", "Workflow Name", "Path"]
-    };
+    let header_cells = ["", "ST", "TR", "NAME", "PATH", "JOBS"];
     let header = Row::new(
         header_cells
             .iter()
@@ -42,102 +44,316 @@ fn render_workflow_list(f: &mut Frame<'_>, app: &mut App, area: Rect) {
     )
     .height(1);
 
-    let diff_active = app.diff_filter_active;
     let spinner_frame = app.spinner_frame;
-    let rows = app.workflows.iter().map(|workflow| {
-        let checkbox = if workflow.selected {
-            theme::symbols::CHECKBOX_ON
-        } else {
-            theme::symbols::CHECKBOX_OFF
-        };
-
-        let (status_symbol, status_style) =
-            theme::workflow_status_animated(&workflow.status, spinner_frame);
-
-        let path_display = workflow.path.to_string_lossy();
-        let path_shortened = if path_display.len() > 30 {
-            let start = path_display
-                .char_indices()
-                .rev()
-                .nth(29)
-                .map(|(i, _)| i)
-                .unwrap_or(0);
-            format!("\u{2026}{}", &path_display[start..])
-        } else {
-            path_display.to_string()
-        };
-
-        let mut cells = vec![
-            Cell::from(checkbox).style(Style::default().fg(COLORS.success)),
-            Cell::from(status_symbol).style(status_style),
-        ];
-
-        if diff_active {
+    let rows: Vec<Row> = app
+        .workflows
+        .iter()
+        .map(|workflow| {
+            let checkbox = if workflow.selected {
+                theme::symbols::CHECKBOX_ON
+            } else {
+                theme::symbols::CHECKBOX_OFF
+            };
+            let (status_symbol, status_style) =
+                theme::workflow_status_animated(&workflow.status, spinner_frame);
             let (trigger_symbol, trigger_style) = match &workflow.trigger_match {
                 Some(TriggerMatchStatus::Matched(_)) => {
-                    ("\u{25cf}", Style::default().fg(Color::Green)) // filled circle
+                    ("●", Style::default().fg(COLORS.success))
                 }
                 Some(TriggerMatchStatus::Skipped(_)) => {
-                    ("\u{25cb}", Style::default().fg(Color::DarkGray)) // empty circle
+                    ("○", Style::default().fg(COLORS.text_muted))
                 }
-                None => ("-", Style::default().fg(Color::DarkGray)),
+                None => (" ", Style::default().fg(COLORS.text_muted)),
             };
-            cells.push(Cell::from(trigger_symbol).style(trigger_style));
-        }
 
-        cells.push(
-            Cell::from(workflow.name.clone()).style(
-                Style::default()
-                    .fg(COLORS.text)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        );
-        cells.push(Cell::from(path_shortened).style(theme::muted_style()));
+            let path_display = workflow.path.to_string_lossy();
+            let path_shortened = if path_display.len() > 40 {
+                let start = path_display
+                    .char_indices()
+                    .rev()
+                    .nth(39)
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                format!("…{}", &path_display[start..])
+            } else {
+                path_display.to_string()
+            };
 
-        Row::new(cells)
-    });
+            let jobs_n = workflow.job_names.len();
+            Row::new(vec![
+                Cell::from(checkbox).style(Style::default().fg(if workflow.selected {
+                    COLORS.success
+                } else {
+                    COLORS.text_muted
+                })),
+                Cell::from(status_symbol).style(status_style),
+                Cell::from(trigger_symbol).style(trigger_style),
+                Cell::from(workflow.name.clone()).style(
+                    Style::default()
+                        .fg(COLORS.text)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Cell::from(path_shortened).style(theme::muted_style()),
+                Cell::from(format!("{}", jobs_n))
+                    .style(Style::default().fg(COLORS.text_muted)),
+            ])
+        })
+        .collect();
 
-    let widths: Vec<Constraint> = if app.diff_filter_active {
-        vec![
-            Constraint::Length(5),      // Checkbox
-            Constraint::Length(3),      // Status
-            Constraint::Length(3),      // Trigger
-            Constraint::Percentage(42), // Name
-            Constraint::Percentage(42), // Path
-        ]
-    } else {
-        vec![
-            Constraint::Length(5),      // Checkbox
-            Constraint::Length(3),      // Status
-            Constraint::Percentage(45), // Name
-            Constraint::Percentage(45), // Path
-        ]
-    };
+    let widths = [
+        Constraint::Length(3), // checkbox
+        Constraint::Length(2), // status
+        Constraint::Length(2), // trigger
+        Constraint::Min(16),   // name
+        Constraint::Min(16),   // path
+        Constraint::Length(5), // jobs
+    ];
 
-    let workflows_table = Table::new(rows, widths)
+    let table = Table::new(rows, widths)
         .header(header)
-        .block(theme::block(&block_title))
+        .block(theme::block_focused(&block_title))
         .highlight_style(theme::selected_style())
         .highlight_symbol(theme::symbols::SELECTED);
 
     let mut table_state = TableState::default();
     table_state.select(app.workflow_list_state.selected());
 
-    // Use inner area with margin for consistent spacing
-    let inner = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(0)].as_ref())
-        .margin(1)
-        .split(area);
-
-    f.render_stateful_widget(workflows_table, inner[0], &mut table_state);
-
-    // Update the app list state to match the table state
+    f.render_stateful_widget(table, area, &mut table_state);
     app.workflow_list_state.select(table_state.selected());
 }
 
+fn render_right_column(f: &mut Frame<'_>, app: &App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(11),
+            Constraint::Length(7),
+            Constraint::Min(0),
+        ])
+        .split(area);
+
+    render_preview(f, app, chunks[0]);
+    render_trigger_filter(f, app, chunks[1]);
+    render_quick_actions(f, chunks[2]);
+}
+
+fn render_preview(f: &mut Frame<'_>, app: &App, area: Rect) {
+    let block = theme::block("Preview");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    let selected = app
+        .workflow_list_state
+        .selected()
+        .and_then(|i| app.workflows.get(i));
+
+    let Some(wf) = selected else {
+        lines.push(Line::from(Span::styled(
+            "(no workflow selected)",
+            Style::default().fg(COLORS.text_muted),
+        )));
+        f.render_widget(Paragraph::new(lines), inner_area);
+        return;
+    };
+
+    if let Some(def) = wf.definition.as_ref() {
+        lines.push(Line::from(vec![
+            Span::styled("name: ", Style::default().fg(COLORS.accent)),
+            Span::styled(
+                def.name.clone(),
+                Style::default()
+                    .fg(COLORS.text)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        let triggers = if def.on.is_empty() {
+            "—".to_string()
+        } else {
+            def.on.join(", ")
+        };
+        lines.push(Line::from(vec![
+            Span::styled("on:   ", Style::default().fg(COLORS.accent)),
+            Span::styled(triggers, Style::default().fg(COLORS.text_dim)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("jobs: ", Style::default().fg(COLORS.accent)),
+            Span::styled(
+                format!("{}", def.jobs.len()),
+                Style::default().fg(COLORS.text_dim),
+            ),
+        ]));
+        let chain = build_chain(def);
+        lines.push(Line::from(vec![Span::styled(
+            chain,
+            Style::default().fg(COLORS.text_muted),
+        )]));
+        lines.push(Line::from(""));
+        let mut badges: Vec<Span> = Vec::new();
+        let needs_count = def
+            .jobs
+            .values()
+            .filter(|j| j.needs.as_ref().is_some_and(|n| !n.is_empty()))
+            .count();
+        if needs_count > 0 {
+            badges.push(theme::badge_outline(
+                format!("needs: {}", needs_count),
+                BadgeKind::Success,
+            ));
+            badges.push(Span::raw(" "));
+        }
+        let matrix_jobs = def
+            .jobs
+            .values()
+            .filter(|j| j.strategy.is_some())
+            .count();
+        if matrix_jobs > 0 {
+            badges.push(theme::badge_outline(
+                format!("matrix: {}", matrix_jobs),
+                BadgeKind::Info,
+            ));
+            badges.push(Span::raw(" "));
+        }
+        let uses_count = def
+            .jobs
+            .values()
+            .flat_map(|j| j.steps.iter())
+            .filter(|s| s.uses.is_some())
+            .count();
+        if uses_count > 0 {
+            badges.push(theme::badge_outline(
+                format!("uses: {}", uses_count),
+                BadgeKind::Warning,
+            ));
+        }
+        if !badges.is_empty() {
+            lines.push(Line::from(badges));
+        }
+    } else {
+        lines.push(Line::from(vec![Span::styled(
+            wf.name.clone(),
+            Style::default()
+                .fg(COLORS.text)
+                .add_modifier(Modifier::BOLD),
+        )]));
+        lines.push(Line::from(Span::styled(
+            "(failed to parse — check YAML)",
+            Style::default().fg(COLORS.text_muted),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled("jobs: ", Style::default().fg(COLORS.accent)),
+            Span::styled(
+                format!("{}", wf.job_names.len()),
+                Style::default().fg(COLORS.text_dim),
+            ),
+        ]));
+    }
+
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner_area);
+}
+
+fn build_chain(def: &wrkflw_parser::workflow::WorkflowDefinition) -> String {
+    use crate::components::dag::topo_levels;
+    let levels = topo_levels(def);
+    if levels.is_empty() {
+        return String::new();
+    }
+    levels
+        .into_iter()
+        .map(|layer| layer.join(","))
+        .collect::<Vec<_>>()
+        .join(" → ")
+}
+
+fn render_trigger_filter(f: &mut Frame<'_>, app: &App, area: Rect) {
+    let block = theme::block_focused("Trigger filter");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    if app.diff_filter_active {
+        let matched = app
+            .workflows
+            .iter()
+            .filter(|w| matches!(w.trigger_match, Some(TriggerMatchStatus::Matched(_))))
+            .count();
+        let skipped = app
+            .workflows
+            .iter()
+            .filter(|w| matches!(w.trigger_match, Some(TriggerMatchStatus::Skipped(_))))
+            .count();
+
+        let lines = vec![
+            Line::from(vec![
+                Span::styled("event: ", Style::default().fg(COLORS.text_dim)),
+                theme::badge_solid(app.diff_filter_event.clone(), BadgeKind::Info),
+            ]),
+            Line::from(vec![
+                Span::styled("●", Style::default().fg(COLORS.success)),
+                Span::raw(" matches → "),
+                Span::styled(
+                    format!("{}", matched),
+                    Style::default().fg(COLORS.text).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("   "),
+                Span::styled("○", Style::default().fg(COLORS.text_muted)),
+                Span::raw(" skipped → "),
+                Span::styled(
+                    format!("{}", skipped),
+                    Style::default().fg(COLORS.text).add_modifier(Modifier::BOLD),
+                ),
+            ]),
+        ];
+        f.render_widget(Paragraph::new(lines), inner_area);
+    } else {
+        let lines = vec![
+            Line::from(Span::styled(
+                "diff filter disabled",
+                Style::default().fg(COLORS.text_muted),
+            )),
+            Line::from(vec![
+                Span::styled("press ", Style::default().fg(COLORS.text_dim)),
+                theme::key_chip("d"),
+                Span::styled(
+                    " to enable",
+                    Style::default().fg(COLORS.text_dim),
+                ),
+            ]),
+        ];
+        f.render_widget(Paragraph::new(lines), inner_area);
+    }
+}
+
+fn render_quick_actions(f: &mut Frame<'_>, area: Rect) {
+    let block = theme::block("Quick actions");
+    let inner_area = block.inner(area);
+    f.render_widget(block, area);
+
+    let actions = [
+        ("r", "Run selected", BadgeKind::Success),
+        ("v", "Validate only", BadgeKind::Info),
+        ("t", "Trigger remote", BadgeKind::Trigger),
+        ("e", "Cycle runtime", BadgeKind::Warning),
+        ("d", "Toggle diff filter", BadgeKind::Accent),
+        ("?", "Help", BadgeKind::Dim),
+    ];
+
+    let lines: Vec<Line> = actions
+        .iter()
+        .map(|(k, label, kind)| {
+            Line::from(vec![
+                theme::key_chip(*k),
+                Span::raw("  "),
+                Span::styled(label.to_string(), Style::default().fg(COLORS.text)),
+                Span::raw("  "),
+                Span::styled("▸", Style::default().fg(kind.fg())),
+            ])
+        })
+        .collect();
+
+    f.render_widget(Paragraph::new(lines), inner_area);
+}
+
 fn render_job_selection(f: &mut Frame<'_>, app: &mut App, area: Rect) {
-    // Get workflow name for the header
     let workflow_name = app
         .workflow_list_state
         .selected()
@@ -160,13 +376,10 @@ fn render_job_selection(f: &mut Frame<'_>, app: &mut App, area: Rect) {
         ])
     });
 
-    let widths = [
-        Constraint::Length(4),      // Number column
-        Constraint::Percentage(90), // Job name column
-    ];
+    let widths = [Constraint::Length(4), Constraint::Percentage(90)];
     let jobs_table = Table::new(rows, widths)
         .header(header)
-        .block(theme::block(&block_title))
+        .block(theme::block_focused(&block_title))
         .highlight_style(theme::selected_style())
         .highlight_symbol(theme::symbols::SELECTED);
 
@@ -180,4 +393,18 @@ fn render_job_selection(f: &mut Frame<'_>, app: &mut App, area: Rect) {
         .split(area);
 
     f.render_stateful_widget(jobs_table, inner[0], &mut table_state);
+}
+
+// ── Helpers used by other tabs (kept here so badges around statuses stay
+//    consistent with the dashboard styling). Currently unused publicly; kept
+//    as a marker that this is the canonical location for new dashboard helpers.
+#[allow(dead_code)]
+fn workflow_status_badge(status: &WorkflowStatus) -> Span<'static> {
+    match status {
+        WorkflowStatus::Running => theme::badge_solid("RUNNING", BadgeKind::Info),
+        WorkflowStatus::Success => theme::badge_outline("SUCCESS", BadgeKind::Success),
+        WorkflowStatus::Failed => theme::badge_outline("FAILED", BadgeKind::Error),
+        WorkflowStatus::Skipped => theme::badge_outline("SKIPPED", BadgeKind::Warning),
+        WorkflowStatus::NotStarted => theme::badge_outline("IDLE", BadgeKind::Dim),
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the TUI redesign from the Claude Design handoff bundle. Three of the eight designed screens land now; the rest are scoped for follow-up PRs that need real feature plumbing first.

- **Visual DNA**: palette swapped to exact RGB from the design (`#5fd3f3` cyan, `#f5d76e` yellow, `#8fce8f` green, `#d68cff` trigger purple, …) so the TUI looks the same on every terminal. New `BadgeKind`-based badge / key-chip / pulse helpers in `theme.rs`.
- **Title bar** (`views/title_bar.rs`): flat 1-row with brand mark, numbered tabs, right-side pulsing LIVE indicator + runtime badge.
- **Status bar** (`views/status_bar.rs`): left-aligned `[key] desc` chips, right-aligned validation/runtime/availability/workflow count. The string-blob `build_context_help` is replaced with a per-mode `Vec<(key, desc)>`.
- **Workflows tab → Dashboard** (`views/workflows_tab.rs`): 60/40 split. Table on the left grows trigger-match dot + job-count columns. Right column stacks **Preview** (parsed name / on / jobs / chain / counts), **Trigger filter** (live match/skip counts), **Quick actions** (six labelled key tiles).
- **Execution tab → Live Run** (`views/execution_tab.rs`): three panes — **Jobs** (synthesised from `Workflow.job_names` so pending jobs show too) · **Steps + Live output** · **Mini DAG** (topo levels from `Job.needs`) + **Timing chart**.
- **Job detail → Step Inspector** (`views/job_detail.rs`): tabbed sub-view — Output / Env / Files / Matrix / Timeline. `Tab` cycles them when `detailed_view` is true. Env/Files render honest placeholders because per-step env snapshots and workspace-diff capture don't exist in the executor yet.
- **New components**: `components/dag.rs`, `components/progress_dots.rs`, `components/timing.rs` — small render helpers used by Live Run and Step Inspector.
- **Data**: `Workflow` now carries an `Arc<WorkflowDefinition>` populated at load time so the Preview pane and mini DAG read real data without re-parsing on every frame. `App` gains `step_inspector_tab: usize` plus a `Tab`/`BackTab` handler scoped to detailed view.

## What's deferred (and why)

Out of scope for this PR — design screens 4-8:

| Screen | Why deferred |
|---|---|
| 4 · DAG full view | Largely covered by the mini DAG; full screen needs zoom/pan handling. |
| 5 · Matrix expansion | Matrix execution support in the executor is partial. |
| 6 · Run history + diff | No persisted history store today. |
| 7 · Secrets manager | Vault/AWS/file routing UI without backing providers is theatre. |
| 8 · Remote trigger | `wrkflw trigger` exists as CLI; UI needs a modal flow. |

Tweaks panel (theme/accent/density switcher) is also deferred — single dark theme for now, but `theme.rs` is structured so a future runtime theme switcher is a `set_theme(&Theme)` call.

## Test plan

- [x] \`cargo build --workspace\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p wrkflw-ui\` — 25/25 passing
- [x] \`cargo test --workspace\` — exit 0
- [x] Smoke-test interactively: \`cargo run -- tui .\` from a repo with workflows; verify Dashboard renders, \`Tab\` switches top-level tabs, \`Enter\` on a job opens Step Inspector, \`Tab\` cycles inspector sub-tabs, \`Esc\` returns.
- [x] Sanity-check colours in iTerm2 + a 16-colour terminal — RGB should render; older terminals will downgrade gracefully via ratatui.