### PR TITLE
feat: WRKFLW_CONTAINER_WAIT_SECS env var (default 900s, was 300s/360s)

### DIFF
--- a/crates/executor/src/docker.rs
+++ b/crates/executor/src/docker.rs
@@ -19,6 +19,22 @@ use wrkflw_utils::fd;
 
 static RUNNING_CONTAINERS: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
 static CREATED_NETWORKS: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+/// Per-container wait timeout, configurable via the
+/// `WRKFLW_CONTAINER_WAIT_SECS` env var. Defaults to 900 seconds (15
+/// minutes) so cold cargo / npm builds inside the runner image have
+/// breathing room before wrkflw declares the container failed.
+///
+/// Setting `WRKFLW_CONTAINER_WAIT_SECS=0` is treated as "no override"
+/// and falls back to the default.
+fn container_wait_timeout() -> std::time::Duration {
+    let secs: u64 = std::env::var("WRKFLW_CONTAINER_WAIT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(900);
+    std::time::Duration::from_secs(secs)
+}
 // Map to track customized images for a job
 #[allow(dead_code)]
 static CUSTOMIZED_IMAGES: Lazy<Mutex<HashMap<String, String>>> =
@@ -1036,9 +1052,10 @@ impl DockerRuntime {
             }
         }
 
-        // Wait for container to finish with a timeout (300 seconds)
+        // Wait for container to finish. Timeout is configurable via
+        // `WRKFLW_CONTAINER_WAIT_SECS` (default: 900s / 15 minutes).
         let wait_result = tokio::time::timeout(
-            std::time::Duration::from_secs(300),
+            container_wait_timeout(),
             self.docker
                 .wait_container::<String>(&container.id, None)
                 .collect::<Vec<_>>(),

--- a/crates/executor/src/podman.rs
+++ b/crates/executor/src/podman.rs
@@ -14,6 +14,23 @@ use wrkflw_utils;
 use wrkflw_utils::fd;
 
 static RUNNING_CONTAINERS: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+/// Per-container wait timeout, configurable via the
+/// `WRKFLW_CONTAINER_WAIT_SECS` env var. Defaults to 900 seconds (15
+/// minutes) so cold cargo / npm builds inside the runner image have
+/// breathing room before wrkflw declares the container failed.
+///
+/// Setting `WRKFLW_CONTAINER_WAIT_SECS=0` is treated as "no override"
+/// and falls back to the default.
+fn container_wait_timeout() -> std::time::Duration {
+    let secs: u64 = std::env::var("WRKFLW_CONTAINER_WAIT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(900);
+    std::time::Duration::from_secs(secs)
+}
+
 // Map to track customized images for a job
 #[allow(dead_code)]
 static CUSTOMIZED_IMAGES: Lazy<Mutex<HashMap<String, String>>> =
@@ -136,13 +153,15 @@ impl PodmanRuntime {
         }
     }
 
-    /// Execute a podman command with proper error handling and timeout
+    /// Execute a podman command with proper error handling and timeout.
+    /// Honors the `WRKFLW_CONTAINER_WAIT_SECS` env var (default 900s);
+    /// the upstream value was 360s.
     async fn execute_podman_command(
         &self,
         args: &[&str],
         input: Option<&str>,
     ) -> Result<ContainerOutput, ContainerError> {
-        let timeout_duration = std::time::Duration::from_secs(360); // 6 minutes timeout
+        let timeout_duration = container_wait_timeout();
 
         let result = tokio::time::timeout(timeout_duration, async {
             let mut cmd = Command::new("podman");
@@ -477,7 +496,8 @@ impl ContainerRuntime for PodmanRuntime {
         // Print detailed debugging info
         wrkflw_logging::info(&format!("Podman: Running container with image: {}", image));
 
-        let timeout_duration = std::time::Duration::from_secs(360); // 6 minutes timeout
+        // Honors WRKFLW_CONTAINER_WAIT_SECS (default 900s).
+        let timeout_duration = container_wait_timeout();
 
         // Run the entire container operation with a timeout
         match tokio::time::timeout(
@@ -488,7 +508,10 @@ impl ContainerRuntime for PodmanRuntime {
         {
             Ok(result) => result,
             Err(_) => {
-                wrkflw_logging::error("Podman operation timed out after 360 seconds");
+                wrkflw_logging::error(&format!(
+                    "Podman operation timed out after {}s",
+                    timeout_duration.as_secs()
+                ));
                 Err(ContainerError::ContainerExecution(
                     "Operation timed out".to_string(),
                 ))


### PR DESCRIPTION
## Problem

Both runtimes hardcode container-wait timeouts that are too tight for
non-trivial workflows:

- **Docker** (`crates/executor/src/docker.rs`): the
  `wait_container::<String>` call inside `run_container` is wrapped in
  `tokio::time::timeout(Duration::from_secs(300), ...)`. Cold cargo /
  npm builds inside the runner image routinely exceed 5 minutes,
  causing wrkflw to log `Container wait operation timed out, treating
  as failure` and report `exit_code = -1` while the build container
  is still actively making progress.
- **Podman** (`crates/executor/src/podman.rs`): both
  `execute_podman_command` and `run_container` wrap their work in
  `tokio::time::timeout(Duration::from_secs(360), ...)`. Same failure
  mode for Podman users.

There's no way for the operator to override this without rebuilding
wrkflw from source.

## Concrete repro (the case we hit)

We're using wrkflw on a self-hosted CI runner LXC. The workflow
includes a Rust workspace with `aws-sdk-s3` in the dep tree (~600
crates). On a cold cargo cache the build takes ~7 minutes inside the
container. wrkflw kills the wait at 300s and reports failure even
though `docker logs` shows compilation is still progressing.

## Fix

Add a `container_wait_timeout()` helper to both runtimes that reads
`WRKFLW_CONTAINER_WAIT_SECS` (defaulting to 900s / 15 minutes when
unset, malformed, or zero):

```rust
fn container_wait_timeout() -> std::time::Duration {
    let secs: u64 = std::env::var("WRKFLW_CONTAINER_WAIT_SECS")
        .ok()
        .and_then(|s| s.parse().ok())
        .filter(|n| *n > 0)
        .unwrap_or(900);
    std::time::Duration::from_secs(secs)
}
```

Both runtimes call it in place of the hardcoded literals.

## Why 900s?

- 5 min was already too tight (the failure case above).
- 6 min (the Podman value) is still tight for a workspace with heavy
  proc-macro / SDK deps.
- 15 min covers cold cargo and cold node_modules without being
  comically large. Operators with shorter jobs can lower it; operators
  running large workspaces can raise it.

The variable is opt-in by name so existing users see a saner default
without having to set anything.

## Drive-by

The Podman runtime's "operation timed out after 360 seconds" log line
now reflects the actual configured timeout instead of the literal
360.

## Tested

- `cargo build -p wrkflw-executor` is clean against this branch.
- The default-on-no-env behaviour matches `Duration::from_secs(900)`.
- `WRKFLW_CONTAINER_WAIT_SECS=0` (and other malformed values) fall
  through to the default rather than producing a 0-second timeout
  that would break every container.

## Use case

We're shipping this in our `gnostr-cloud` runner agent
([MonumentalSystems/gnostr-cloud](https://github.com/MonumentalSystems/gnostr-cloud))
where the Rust ci-runner sets
`WRKFLW_CONTAINER_WAIT_SECS=900` (and exposes a
`GNOSTR_CLOUD_CI_CONTAINER_WAIT_SECS` operator override that's
forwarded into the wrkflw subprocess). Until this lands upstream we'll
install wrkflw from this fork branch; once it lands we'll switch back
to crates.io.

Happy to bikeshed the env var name / default value / etc.