### PR TITLE
feat(runtime): add Auto runtime that detects Docker then Podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .indxr-cache/
 .claude/todos/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -103,8 +103,11 @@ wrkflw validate --verbose path/to/workflow.yml
 ### Execution
 
 ```bash
-# Run with Docker (default)
+# Run with auto-detection (default: tries Docker, then Podman, then emulation)
 wrkflw run .github/workflows/ci.yml
+
+# Run with Docker explicitly
+wrkflw run --runtime docker .github/workflows/ci.yml
 
 # Run with Podman
 wrkflw run --runtime podman .github/workflows/ci.yml
@@ -214,7 +217,8 @@ wrkflw trigger-gitlab --branch main --variable key=value
 
 | Mode | Description | Best for |
 |------|-------------|----------|
-| **Docker** (default) | Full container isolation, closest to GitHub runners | Production, CI/CD |
+| **Auto** (default) | Detects Docker, then Podman, then falls back to emulation | Most users |
+| **Docker** | Full container isolation, closest to GitHub runners | Production, CI/CD |
 | **Podman** | Rootless containers, no daemon required | Security-conscious environments |
 | **Emulation** | Runs directly on host, no containers needed | Quick local testing |
 | **Secure Emulation** | Sandboxed host processes with filesystem/network restrictions | Running untrusted workflows without a container runtime |

--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -158,6 +158,7 @@ async fn execute_github_workflow(
     env_context.insert(
         "WRKFLW_RUNTIME_MODE".to_string(),
         match config.runtime_type {
+            RuntimeType::Auto => "auto".to_string(),
             RuntimeType::Emulation => "emulation".to_string(),
             RuntimeType::SecureEmulation => "secure_emulation".to_string(),
             RuntimeType::Docker => "docker".to_string(),
@@ -351,6 +352,7 @@ async fn execute_gitlab_pipeline(
     env_context.insert(
         "WRKFLW_RUNTIME_MODE".to_string(),
         match config.runtime_type {
+            RuntimeType::Auto => "auto".to_string(),
             RuntimeType::Emulation => "emulation".to_string(),
             RuntimeType::SecureEmulation => "secure_emulation".to_string(),
             RuntimeType::Docker => "docker".to_string(),
@@ -568,6 +570,32 @@ fn initialize_runtime(
     preserve_containers_on_failure: bool,
 ) -> Result<Box<dyn ContainerRuntime>, ExecutionError> {
     match runtime_type {
+        RuntimeType::Auto => {
+            if docker::is_available() {
+                wrkflw_logging::info("Auto-detected Docker runtime");
+                match docker::DockerRuntime::new_with_config(preserve_containers_on_failure) {
+                    Ok(r) => return Ok(Box::new(r)),
+                    Err(e) => wrkflw_logging::error(&format!(
+                        "Failed to initialize Docker runtime: {}, trying Podman",
+                        e
+                    )),
+                }
+            }
+            if podman::is_available() {
+                wrkflw_logging::info("Auto-detected Podman runtime");
+                match podman::PodmanRuntime::new_with_config(preserve_containers_on_failure) {
+                    Ok(r) => return Ok(Box::new(r)),
+                    Err(e) => wrkflw_logging::error(&format!(
+                        "Failed to initialize Podman runtime: {}, falling back to emulation mode",
+                        e
+                    )),
+                }
+            }
+            wrkflw_logging::error(
+                "No container runtime found (tried Docker and Podman), falling back to emulation mode",
+            );
+            Ok(Box::new(emulation::EmulationRuntime::new()))
+        }
         RuntimeType::Docker => {
             if docker::is_available() {
                 // Handle the Result returned by DockerRuntime::new()
@@ -613,6 +641,8 @@ fn initialize_runtime(
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeType {
+    /// Detect Docker first, then Podman, then fall back to emulation.
+    Auto,
     Docker,
     Podman,
     Emulation,
@@ -9391,6 +9421,28 @@ runs:
             runtime.build_count.load(Ordering::SeqCst),
             1,
             "build_image should be called exactly once despite concurrent jobs"
+        );
+    }
+
+    // --- RuntimeType::Auto tests ---
+
+    #[test]
+    fn auto_is_distinct_from_concrete_variants() {
+        assert_ne!(RuntimeType::Auto, RuntimeType::Docker);
+        assert_ne!(RuntimeType::Auto, RuntimeType::Podman);
+        assert_ne!(RuntimeType::Auto, RuntimeType::Emulation);
+        assert_ne!(RuntimeType::Auto, RuntimeType::SecureEmulation);
+    }
+
+    #[test]
+    fn initialize_runtime_auto_does_not_panic() {
+        // Auto should always succeed (falls back to emulation when nothing is available).
+        // This exercises the full cascade on whatever the test environment provides.
+        let result = initialize_runtime(RuntimeType::Auto, false);
+        assert!(
+            result.is_ok(),
+            "Auto runtime initialization returned Err: {:?}",
+            result.err()
         );
     }
 }

--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -79,8 +79,9 @@ fn is_gitlab_pipeline(path: &Path) -> bool {
 /// Execute a GitHub Actions workflow file locally
 async fn execute_github_workflow(
     workflow_path: &Path,
-    config: ExecutionConfig,
+    mut config: ExecutionConfig,
 ) -> Result<ExecutionResult, ExecutionError> {
+    config.runtime_type = detect_runtime(config.runtime_type);
     // 1. Parse workflow file
     let workflow = parse_workflow(workflow_path)?;
 
@@ -307,8 +308,9 @@ async fn execute_github_workflow(
 /// Execute a GitLab CI/CD pipeline locally
 async fn execute_gitlab_pipeline(
     pipeline_path: &Path,
-    config: ExecutionConfig,
+    mut config: ExecutionConfig,
 ) -> Result<ExecutionResult, ExecutionError> {
+    config.runtime_type = detect_runtime(config.runtime_type);
     wrkflw_logging::info("Executing GitLab CI/CD pipeline");
 
     // 1. Parse the GitLab pipeline file
@@ -564,41 +566,35 @@ fn resolve_gitlab_dependencies(
     Ok(execution_plan)
 }
 
+/// Resolves `RuntimeType::Auto` to a concrete runtime by probing availability.
+/// All other variants pass through unchanged.
+pub fn detect_runtime(runtime_type: RuntimeType) -> RuntimeType {
+    match runtime_type {
+        RuntimeType::Auto => {
+            if docker::is_available() {
+                RuntimeType::Docker
+            } else if podman::is_available() {
+                RuntimeType::Podman
+            } else {
+                RuntimeType::Emulation
+            }
+        }
+        other => other,
+    }
+}
+
 // Determine if Docker/Podman is available or fall back to emulation
 fn initialize_runtime(
     runtime_type: RuntimeType,
     preserve_containers_on_failure: bool,
 ) -> Result<Box<dyn ContainerRuntime>, ExecutionError> {
     match runtime_type {
-        RuntimeType::Auto => {
-            if docker::is_available() {
-                wrkflw_logging::info("Auto-detected Docker runtime");
-                match docker::DockerRuntime::new_with_config(preserve_containers_on_failure) {
-                    Ok(r) => return Ok(Box::new(r)),
-                    Err(e) => wrkflw_logging::error(&format!(
-                        "Failed to initialize Docker runtime: {}, trying Podman",
-                        e
-                    )),
-                }
-            }
-            if podman::is_available() {
-                wrkflw_logging::info("Auto-detected Podman runtime");
-                match podman::PodmanRuntime::new_with_config(preserve_containers_on_failure) {
-                    Ok(r) => return Ok(Box::new(r)),
-                    Err(e) => wrkflw_logging::error(&format!(
-                        "Failed to initialize Podman runtime: {}, falling back to emulation mode",
-                        e
-                    )),
-                }
-            }
-            wrkflw_logging::error(
-                "No container runtime found (tried Docker and Podman), falling back to emulation mode",
-            );
-            Ok(Box::new(emulation::EmulationRuntime::new()))
-        }
+        RuntimeType::Auto => initialize_runtime(
+            detect_runtime(RuntimeType::Auto),
+            preserve_containers_on_failure,
+        ),
         RuntimeType::Docker => {
             if docker::is_available() {
-                // Handle the Result returned by DockerRuntime::new()
                 match docker::DockerRuntime::new_with_config(preserve_containers_on_failure) {
                     Ok(docker_runtime) => Ok(Box::new(docker_runtime)),
                     Err(e) => {
@@ -616,17 +612,9 @@ fn initialize_runtime(
         }
         RuntimeType::Podman => {
             if podman::is_available() {
-                // Handle the Result returned by PodmanRuntime::new()
-                match podman::PodmanRuntime::new_with_config(preserve_containers_on_failure) {
-                    Ok(podman_runtime) => Ok(Box::new(podman_runtime)),
-                    Err(e) => {
-                        wrkflw_logging::error(&format!(
-                            "Failed to initialize Podman runtime: {}, falling back to emulation mode",
-                            e
-                        ));
-                        Ok(Box::new(emulation::EmulationRuntime::new()))
-                    }
-                }
+                Ok(Box::new(podman::PodmanRuntime::new_unchecked(
+                    preserve_containers_on_failure,
+                )))
             } else {
                 wrkflw_logging::error("Podman not available, falling back to emulation mode");
                 Ok(Box::new(emulation::EmulationRuntime::new()))

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -18,5 +18,6 @@ pub(crate) mod workflow_commands;
 // Re-export public items
 pub use docker::cleanup_resources;
 pub use engine::{
-    execute_workflow, ExecutionConfig, JobResult, JobStatus, RuntimeType, StepResult, StepStatus,
+    detect_runtime, execute_workflow, ExecutionConfig, JobResult, JobStatus, RuntimeType,
+    StepResult, StepStatus,
 };

--- a/crates/executor/src/podman.rs
+++ b/crates/executor/src/podman.rs
@@ -29,16 +29,20 @@ impl PodmanRuntime {
     }
 
     pub fn new_with_config(preserve_containers_on_failure: bool) -> Result<Self, ContainerError> {
-        // Check if podman command is available
         if !is_available() {
             return Err(ContainerError::ContainerStart(
                 "Podman is not available on this system".to_string(),
             ));
         }
+        Ok(Self::new_unchecked(preserve_containers_on_failure))
+    }
 
-        Ok(PodmanRuntime {
+    /// Construct without re-probing availability. Callers must have already verified
+    /// that Podman is available via `is_available()`.
+    pub(crate) fn new_unchecked(preserve_containers_on_failure: bool) -> Self {
+        PodmanRuntime {
             preserve_containers_on_failure,
-        })
+        }
     }
 
     // Add a method to store and retrieve customized images (e.g., with Python installed)

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -329,50 +329,38 @@ impl App {
         step_table_state.select(Some(0));
 
         // Check container runtime availability if container runtime is selected
-        let initial_logs = Vec::new();
+        let mut initial_logs = Vec::new();
         let runtime_type = match runtime_type {
             RuntimeType::Auto => {
-                // Try Docker first, then Podman, then fall back to emulation.
-                let is_docker_available = std::thread::scope(|s| {
-                    let h = s.spawn(|| {
-                        wrkflw_utils::fd::with_stderr_to_null(wrkflw_executor::docker::is_available)
-                            .unwrap_or(false)
-                    });
-                    let start = std::time::Instant::now();
-                    let timeout = std::time::Duration::from_secs(1);
-                    while start.elapsed() < timeout {
-                        if h.is_finished() {
-                            return h.join().unwrap_or(false);
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
-                    false
-                });
-                if is_docker_available {
-                    wrkflw_logging::info("Auto-detected Docker runtime");
-                    RuntimeType::Docker
-                } else {
-                    let is_podman_available = std::thread::scope(|s| {
-                        let h = s.spawn(|| {
-                            wrkflw_utils::fd::with_stderr_to_null(
-                                wrkflw_executor::podman::is_available,
-                            )
-                            .unwrap_or(false)
-                        });
+                let detected = match std::panic::catch_unwind(|| {
+                    std::thread::scope(|s| {
+                        let h = s.spawn(|| wrkflw_executor::detect_runtime(RuntimeType::Auto));
                         let start = std::time::Instant::now();
                         let timeout = std::time::Duration::from_secs(1);
                         while start.elapsed() < timeout {
                             if h.is_finished() {
-                                return h.join().unwrap_or(false);
+                                return h.join().unwrap_or(RuntimeType::Emulation);
                             }
                             std::thread::sleep(std::time::Duration::from_millis(10));
                         }
-                        false
-                    });
-                    if is_podman_available {
-                        wrkflw_logging::info("Auto-detected Podman runtime");
-                        RuntimeType::Podman
-                    } else {
+                        wrkflw_logging::warning(
+                            "Auto runtime detection timed out, falling back to emulation mode",
+                        );
+                        RuntimeType::Emulation
+                    })
+                }) {
+                    Ok(r) => r,
+                    Err(_) => {
+                        wrkflw_logging::warning(
+                            "Auto runtime detection failed with panic, falling back to emulation mode",
+                        );
+                        RuntimeType::Emulation
+                    }
+                };
+                match detected {
+                    RuntimeType::Docker => wrkflw_logging::info("Auto-detected Docker runtime"),
+                    RuntimeType::Podman => wrkflw_logging::info("Auto-detected Podman runtime"),
+                    _ => {
                         initial_logs.push(
                             "No container runtime found (tried Docker and Podman). Using emulation mode instead."
                                 .to_string(),
@@ -380,9 +368,9 @@ impl App {
                         wrkflw_logging::warning(
                             "No container runtime found (tried Docker and Podman). Using emulation mode instead.",
                         );
-                        RuntimeType::Emulation
                     }
                 }
+                detected
             }
             RuntimeType::Docker => {
                 // Use a timeout for the Docker availability check to prevent hanging

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -331,6 +331,59 @@ impl App {
         // Check container runtime availability if container runtime is selected
         let initial_logs = Vec::new();
         let runtime_type = match runtime_type {
+            RuntimeType::Auto => {
+                // Try Docker first, then Podman, then fall back to emulation.
+                let is_docker_available = std::thread::scope(|s| {
+                    let h = s.spawn(|| {
+                        wrkflw_utils::fd::with_stderr_to_null(wrkflw_executor::docker::is_available)
+                            .unwrap_or(false)
+                    });
+                    let start = std::time::Instant::now();
+                    let timeout = std::time::Duration::from_secs(1);
+                    while start.elapsed() < timeout {
+                        if h.is_finished() {
+                            return h.join().unwrap_or(false);
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    false
+                });
+                if is_docker_available {
+                    wrkflw_logging::info("Auto-detected Docker runtime");
+                    RuntimeType::Docker
+                } else {
+                    let is_podman_available = std::thread::scope(|s| {
+                        let h = s.spawn(|| {
+                            wrkflw_utils::fd::with_stderr_to_null(
+                                wrkflw_executor::podman::is_available,
+                            )
+                            .unwrap_or(false)
+                        });
+                        let start = std::time::Instant::now();
+                        let timeout = std::time::Duration::from_secs(1);
+                        while start.elapsed() < timeout {
+                            if h.is_finished() {
+                                return h.join().unwrap_or(false);
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(10));
+                        }
+                        false
+                    });
+                    if is_podman_available {
+                        wrkflw_logging::info("Auto-detected Podman runtime");
+                        RuntimeType::Podman
+                    } else {
+                        initial_logs.push(
+                            "No container runtime found (tried Docker and Podman). Using emulation mode instead."
+                                .to_string(),
+                        );
+                        wrkflw_logging::warning(
+                            "No container runtime found (tried Docker and Podman). Using emulation mode instead.",
+                        );
+                        RuntimeType::Emulation
+                    }
+                }
+            }
             RuntimeType::Docker => {
                 // Use a timeout for the Docker availability check to prevent hanging
                 let is_docker_available = match std::panic::catch_unwind(|| {
@@ -526,6 +579,7 @@ impl App {
 
     pub fn toggle_emulation_mode(&mut self) {
         self.runtime_type = match self.runtime_type {
+            RuntimeType::Auto => RuntimeType::Docker,
             RuntimeType::Docker => RuntimeType::Podman,
             RuntimeType::Podman => RuntimeType::SecureEmulation,
             RuntimeType::SecureEmulation => RuntimeType::Emulation,
@@ -902,6 +956,7 @@ impl App {
 
     pub fn runtime_type_name(&self) -> &str {
         match self.runtime_type {
+            RuntimeType::Auto => "Auto",
             RuntimeType::Docker => "Docker",
             RuntimeType::Podman => "Podman",
             RuntimeType::SecureEmulation => "Secure Emulation",

--- a/crates/ui/src/handlers/workflow.rs
+++ b/crates/ui/src/handlers/workflow.rs
@@ -138,6 +138,26 @@ pub async fn execute_workflow_cli(
 
     // Check container runtime availability if container runtime is selected
     let runtime_type = match runtime_type {
+        RuntimeType::Auto => {
+            if wrkflw_executor::docker::is_available() {
+                wrkflw_logging::info("Auto-detected Docker runtime");
+                RuntimeType::Docker
+            } else if wrkflw_executor::podman::is_available() {
+                wrkflw_logging::info("Auto-detected Podman runtime");
+                RuntimeType::Podman
+            } else {
+                println!(
+                    "{}",
+                    cli_style::warning(
+                        "No container runtime found (tried Docker and Podman). Using emulation mode instead."
+                    )
+                );
+                wrkflw_logging::warning(
+                    "No container runtime found (tried Docker and Podman). Using emulation mode instead.",
+                );
+                RuntimeType::Emulation
+            }
+        }
         RuntimeType::Docker => {
             if !wrkflw_executor::docker::is_available() {
                 println!(
@@ -464,6 +484,33 @@ pub fn start_next_workflow_execution(
 
         // Check container runtime availability again if container runtime is selected
         let runtime_type = match app.runtime_type {
+            RuntimeType::Auto => {
+                let is_docker =
+                    wrkflw_utils::fd::with_stderr_to_null(wrkflw_executor::docker::is_available)
+                        .unwrap_or(false);
+                if is_docker {
+                    wrkflw_logging::info("Auto-detected Docker runtime");
+                    RuntimeType::Docker
+                } else {
+                    let is_podman = wrkflw_utils::fd::with_stderr_to_null(
+                        wrkflw_executor::podman::is_available,
+                    )
+                    .unwrap_or(false);
+                    if is_podman {
+                        wrkflw_logging::info("Auto-detected Podman runtime");
+                        RuntimeType::Podman
+                    } else {
+                        app.logs.push(
+                            "No container runtime found (tried Docker and Podman). Using emulation mode instead."
+                                .to_string(),
+                        );
+                        wrkflw_logging::warning(
+                            "No container runtime found (tried Docker and Podman). Using emulation mode instead.",
+                        );
+                        RuntimeType::Emulation
+                    }
+                }
+            }
             RuntimeType::Docker => {
                 // Use safe FD redirection to check Docker availability
                 let is_docker_available = match wrkflw_utils::fd::with_stderr_to_null(

--- a/crates/ui/src/views/execution_tab.rs
+++ b/crates/ui/src/views/execution_tab.rs
@@ -87,6 +87,7 @@ fn render_summary_strip(f: &mut Frame<'_>, app: &App, idx: usize, area: Rect) {
     // Left: workflow chip
     let (sym, sym_style) = theme::workflow_status_animated(&workflow.status, app.spinner_frame);
     let runtime_kind = match app.runtime_type {
+        RuntimeType::Auto => BadgeKind::Emulation,
         RuntimeType::Docker => BadgeKind::Docker,
         RuntimeType::Podman => BadgeKind::Podman,
         RuntimeType::SecureEmulation => BadgeKind::Secure,

--- a/crates/ui/src/views/status_bar.rs
+++ b/crates/ui/src/views/status_bar.rs
@@ -62,6 +62,7 @@ pub fn render_status_bar(f: &mut Frame<'_>, app: &App, area: Rect) {
     }
     right.push(Span::raw(" "));
     let runtime_badge_kind = match app.runtime_type {
+        RuntimeType::Auto => BadgeKind::Emulation,
         RuntimeType::Docker => BadgeKind::Docker,
         RuntimeType::Podman => BadgeKind::Podman,
         RuntimeType::SecureEmulation => BadgeKind::Secure,

--- a/crates/ui/src/views/title_bar.rs
+++ b/crates/ui/src/views/title_bar.rs
@@ -101,6 +101,7 @@ pub fn render_title_bar(f: &mut Frame<'_>, app: &App, area: Rect) {
         right.push(Span::raw("  "));
     }
     let runtime_kind = match app.runtime_type {
+        RuntimeType::Auto => BadgeKind::Emulation,
         RuntimeType::Docker => BadgeKind::Docker,
         RuntimeType::Podman => BadgeKind::Podman,
         RuntimeType::SecureEmulation => BadgeKind::Secure,

--- a/crates/wrkflw/src/main.rs
+++ b/crates/wrkflw/src/main.rs
@@ -10,6 +10,8 @@ mod watch_cmd;
 
 #[derive(Debug, Clone, ValueEnum)]
 pub(crate) enum RuntimeChoice {
+    /// Detect Docker first, then Podman, then fall back to emulation (default)
+    Auto,
     /// Use Docker containers for isolation
     Docker,
     /// Use Podman containers for isolation
@@ -23,6 +25,7 @@ pub(crate) enum RuntimeChoice {
 impl From<RuntimeChoice> for wrkflw_executor::RuntimeType {
     fn from(choice: RuntimeChoice) -> Self {
         match choice {
+            RuntimeChoice::Auto => wrkflw_executor::RuntimeType::Auto,
             RuntimeChoice::Docker => wrkflw_executor::RuntimeType::Docker,
             RuntimeChoice::Podman => wrkflw_executor::RuntimeType::Podman,
             RuntimeChoice::Emulation => wrkflw_executor::RuntimeType::Emulation,
@@ -78,7 +81,7 @@ enum Commands {
         path: PathBuf,
 
         /// Container runtime to use (docker, podman, emulation, secure-emulation)
-        #[arg(short, long, value_enum, default_value = "docker")]
+        #[arg(short, long, value_enum, default_value = "auto")]
         runtime: RuntimeChoice,
 
         /// Show 'Would execute GitHub action' messages in emulation mode
@@ -170,7 +173,7 @@ enum Commands {
         path: Option<PathBuf>,
 
         /// Container runtime to use (docker, podman, emulation, secure-emulation)
-        #[arg(short, long, value_enum, default_value = "docker")]
+        #[arg(short, long, value_enum, default_value = "auto")]
         runtime: RuntimeChoice,
 
         /// Debounce interval in milliseconds
@@ -255,7 +258,7 @@ enum Commands {
         path: Option<PathBuf>,
 
         /// Container runtime to use (docker, podman, emulation, secure-emulation)
-        #[arg(short, long, value_enum, default_value = "docker")]
+        #[arg(short, long, value_enum, default_value = "auto")]
         runtime: RuntimeChoice,
 
         /// Show 'Would execute GitHub action' messages in emulation mode
@@ -696,7 +699,7 @@ async fn main() {
             #[cfg(feature = "tui")]
             {
                 // Launch TUI by default when no command is provided
-                let runtime_type = wrkflw_executor::RuntimeType::Docker;
+                let runtime_type = wrkflw_executor::RuntimeType::Auto;
 
                 // Call the TUI implementation from the ui crate with default path
                 if let Err(e) =
@@ -932,5 +935,38 @@ fn list_workflows_and_pipelines(verbose: bool, show_jobs: bool) {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_choice_auto_maps_to_runtime_type_auto() {
+        let rt: wrkflw_executor::RuntimeType = RuntimeChoice::Auto.into();
+        assert_eq!(rt, wrkflw_executor::RuntimeType::Auto);
+    }
+
+    #[test]
+    fn runtime_choice_all_variants_map_correctly() {
+        use wrkflw_executor::RuntimeType;
+        assert_eq!(RuntimeType::from(RuntimeChoice::Auto), RuntimeType::Auto);
+        assert_eq!(
+            RuntimeType::from(RuntimeChoice::Docker),
+            RuntimeType::Docker
+        );
+        assert_eq!(
+            RuntimeType::from(RuntimeChoice::Podman),
+            RuntimeType::Podman
+        );
+        assert_eq!(
+            RuntimeType::from(RuntimeChoice::Emulation),
+            RuntimeType::Emulation
+        );
+        assert_eq!(
+            RuntimeType::from(RuntimeChoice::SecureEmulation),
+            RuntimeType::SecureEmulation
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `RuntimeType::Auto` (and `--runtime auto` CLI flag) that probes Docker first, then Podman, then falls back to emulation
- Makes `auto` the default runtime for all subcommands (`run`, `watch`, `tui`) instead of hardcoded `docker`
- Fixes the no-args TUI launch which previously hardcoded `RuntimeType::Docker`, causing Podman-only users to always see a \"Docker is not available\" warning and fall back to emulation

## Test plan

- [x] Run `wrkflw run <workflow>` on a Podman-only machine and confirm it detects Podman automatically (no Docker warning)
- [ ] Run `wrkflw run <workflow>` on a Docker machine and confirm Docker is still selected
- [ ] Run `wrkflw run <workflow>` with no container runtime available and confirm emulation fallback message is shown
- [x] Run `wrkflw` (TUI, no args) on a Podman-only machine and confirm the runtime badge shows Podman
- [x] Confirm `--runtime docker`, `--runtime podman`, `--runtime emulation` still work explicitly
- [x] Run `cargo test -p wrkflw-executor` and `cargo test -p wrkflw` to verify new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)