### PR TITLE
fix: show correct timestamp in execution tab for all TUI log messages

### DIFF
--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -370,10 +370,11 @@ impl App {
                 };
 
                 if !is_docker_available {
-                    initial_logs.push(
-                        "Docker is not available or unresponsive. Using emulation mode instead."
-                            .to_string(),
-                    );
+                    initial_logs.push(format!(
+                        "[{}] {} Docker is not available or unresponsive. Using emulation mode instead.",
+                        Local::now().format("%H:%M:%S"),
+                        wrkflw_logging::symbols::WARNING,
+                    ));
                     wrkflw_logging::warning(
                         "Docker is not available or unresponsive. Using emulation mode instead.",
                     );
@@ -422,10 +423,11 @@ impl App {
                 };
 
                 if !is_podman_available {
-                    initial_logs.push(
-                        "Podman is not available or unresponsive. Using emulation mode instead."
-                            .to_string(),
-                    );
+                    initial_logs.push(format!(
+                        "[{}] {} Podman is not available or unresponsive. Using emulation mode instead.",
+                        Local::now().format("%H:%M:%S"),
+                        wrkflw_logging::symbols::WARNING,
+                    ));
                     wrkflw_logging::warning(
                         "Podman is not available or unresponsive. Using emulation mode instead.",
                     );

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -329,7 +329,7 @@ impl App {
         step_table_state.select(Some(0));
 
         // Check container runtime availability if container runtime is selected
-        let mut initial_logs = Vec::new();
+        let initial_logs = Vec::new();
         let runtime_type = match runtime_type {
             RuntimeType::Docker => {
                 // Use a timeout for the Docker availability check to prevent hanging
@@ -370,11 +370,6 @@ impl App {
                 };
 
                 if !is_docker_available {
-                    initial_logs.push(format!(
-                        "[{}] {} Docker is not available or unresponsive. Using emulation mode instead.",
-                        Local::now().format("%H:%M:%S"),
-                        wrkflw_logging::symbols::WARNING,
-                    ));
                     wrkflw_logging::warning(
                         "Docker is not available or unresponsive. Using emulation mode instead.",
                     );
@@ -423,11 +418,6 @@ impl App {
                 };
 
                 if !is_podman_available {
-                    initial_logs.push(format!(
-                        "[{}] {} Podman is not available or unresponsive. Using emulation mode instead.",
-                        Local::now().format("%H:%M:%S"),
-                        wrkflw_logging::symbols::WARNING,
-                    ));
                     wrkflw_logging::warning(
                         "Podman is not available or unresponsive. Using emulation mode instead.",
                     );
@@ -548,8 +538,7 @@ impl App {
             _ => false,
         };
         self.last_availability_check = Instant::now();
-        self.logs
-            .push(format!("Switched to {} mode", self.runtime_type_name()));
+        self.add_timestamped_log(&format!("Switched to {} mode", self.runtime_type_name()));
     }
 
     /// Cycle through the event names the diff filter simulates.
@@ -762,7 +751,7 @@ impl App {
             for workflow in &mut self.workflows {
                 workflow.trigger_match = None;
             }
-            self.logs.push("Diff filter OFF".to_string());
+            self.add_timestamped_log("Diff filter OFF");
         }
     }
 
@@ -800,7 +789,7 @@ impl App {
                     if self.diff_filter_aborted {
                         self.diff_filter_aborted = false;
                     } else {
-                        self.logs.push("Diff filter: evaluation failed".to_string());
+                        self.add_timestamped_log("Diff filter: evaluation failed");
                     }
                     return;
                 }
@@ -832,7 +821,7 @@ impl App {
                     .iter()
                     .filter(|w| matches!(&w.trigger_match, Some(TriggerMatchStatus::Matched(_))))
                     .count();
-                self.logs.push(format!(
+                self.add_timestamped_log(&format!(
                     "Diff filter ON: {}/{} workflows would trigger",
                     matched,
                     self.workflows.len()
@@ -853,10 +842,12 @@ impl App {
                 // load-bearing to avoid the silent-skip mode this PR
                 // is built to plug.
                 if !warnings.is_empty() {
-                    self.logs
-                        .push(format!("Diff filter: {} warning(s)", warnings.len()));
+                    self.add_timestamped_log(&format!(
+                        "Diff filter: {} warning(s)",
+                        warnings.len()
+                    ));
                     for w in &warnings {
-                        self.logs.push(format!("  warning: {}", w));
+                        self.add_log(format!("  warning: {}", w));
                     }
                 }
 
@@ -866,13 +857,12 @@ impl App {
                 // Surface each failure individually so the YAML/glob
                 // typo is the first thing they see in the log pane.
                 if !parse_failures.is_empty() {
-                    self.logs.push(format!(
+                    self.add_timestamped_log(&format!(
                         "Diff filter: {} workflow file(s) failed to parse and were skipped",
                         parse_failures.len()
                     ));
                     for (path, reason) in &parse_failures {
-                        self.logs
-                            .push(format!("  parse error: {}: {}", path.display(), reason));
+                        self.add_log(format!("  parse error: {}: {}", path.display(), reason));
                     }
                 }
 
@@ -891,8 +881,7 @@ impl App {
                 for workflow in &mut self.workflows {
                     workflow.trigger_match = None;
                 }
-                self.logs
-                    .push(format!("Diff filter: evaluation failed — {}", reason));
+                self.add_timestamped_log(&format!("Diff filter: evaluation failed — {}", reason));
                 self.trim_logs_to_cap();
             }
         }
@@ -1264,8 +1253,10 @@ impl App {
         let target_job = entry.target_job;
         self.workflows[next].status = WorkflowStatus::Running;
         self.current_execution = Some(next);
-        self.logs
-            .push(format!("Executing workflow: {}", self.workflows[next].name));
+        self.add_timestamped_log(&format!(
+            "Executing workflow: {}",
+            self.workflows[next].name
+        ));
         wrkflw_logging::info(&format!(
             "Executing workflow: {}",
             self.workflows[next].name


### PR DESCRIPTION
## Summary

The Execution tab (and Logs tab) was rendering \`??:??:??\` as the timestamp for several categories of TUI-generated log messages. The root cause was that \`process_log_entry\` in \`log_processor.rs\` extracts timestamps from the \`[HH:MM:SS]\` prefix produced by \`wrkflw_logging\`; messages pushed directly via \`self.logs.push(...)\` bypassed that formatting entirely.

Changes in \`crates/ui/src/app/state.rs\`:

- **Removed redundant \`initial_logs.push(...)\` calls** for Docker/Podman unavailability warnings. The \`wrkflw_logging::warning(...)\` call immediately following each already writes an identically-formatted line to the global log store, which \`LogProcessor::get_combined_logs()\` merges into the rendered list. Keeping both caused the warning to appear twice (with potentially different timestamps if the two \`Local::now()\` calls straddled a second boundary). The fix deletes the pushes rather than reformatting them.

- **Replaced all remaining bare \`self.logs.push(...)\` calls with \`self.add_timestamped_log(...)\`** (or \`self.add_log(...)\` for indented sub-items), covering:
  - \`toggle_emulation_mode\` — "Switched to X mode"
  - \`check_diff_filter_results\` — "Diff filter ON/OFF", evaluation failed, warnings, parse errors
  - \`get_next_workflow_to_execute\` — "Executing workflow: ..."

  Using \`add_timestamped_log\` also ensures the \`LOG_BUFFER_CAP\` trim and \`mark_logs_for_update\` are invoked on every push, which the raw push calls were bypassing.

## Test plan

- [x] \`cargo check\` passes with no warnings
- [x] All previously-broken messages now render with a real \`[HH:MM:SS]\` timestamp instead of \`??:??:??\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)