### PR TITLE
fix(ui): show real timestamps for remaining bare TUI log pushes

### DIFF
--- a/crates/ui/src/app/mod.rs
+++ b/crates/ui/src/app/mod.rs
@@ -615,7 +615,9 @@ fn run_tui_event_loop(
                                 "Cannot trigger workflow while another operation is in progress",
                             );
                         } else if app.selected_tab != TAB_WORKFLOWS {
-                            app.add_timestamped_log("Switch to Workflows tab to trigger a workflow");
+                            app.add_timestamped_log(
+                                "Switch to Workflows tab to trigger a workflow",
+                            );
                             wrkflw_logging::warning(
                                 "Switch to Workflows tab to trigger a workflow",
                             );

--- a/crates/ui/src/app/mod.rs
+++ b/crates/ui/src/app/mod.rs
@@ -8,7 +8,6 @@ use crate::views::{
     render_ui, TAB_COUNT, TAB_DAG, TAB_EXECUTION, TAB_HELP, TAB_LOGS, TAB_SECRETS, TAB_TRIGGER,
     TAB_WORKFLOWS,
 };
-use chrono::Local;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers},
     execute,
@@ -57,7 +56,7 @@ pub async fn run_wrkflw_tui(
     );
 
     if app.validation_mode {
-        app.logs.push("Starting in validation mode".to_string());
+        app.add_timestamped_log("Starting in validation mode");
         wrkflw_logging::info("Starting in validation mode");
     }
 
@@ -558,14 +557,12 @@ fn run_tui_event_loop(
                                     if workflow.status == WorkflowStatus::NotStarted {
                                         app.trigger_selected_workflow();
                                     } else if workflow.status == WorkflowStatus::Running {
-                                        app.logs.push(format!(
+                                        let msg = format!(
                                             "Workflow '{}' is already running",
                                             workflow.name
-                                        ));
-                                        wrkflw_logging::warning(&format!(
-                                            "Workflow '{}' is already running",
-                                            workflow.name
-                                        ));
+                                        );
+                                        app.add_timestamped_log(&msg);
+                                        wrkflw_logging::warning(&msg);
                                     } else {
                                         // First, get all the data we need from the workflow
                                         let workflow_name = workflow.name.clone();
@@ -588,19 +585,16 @@ fn run_tui_event_loop(
                                         ));
 
                                         // Add log entries
-                                        app.logs.push(format!(
+                                        app.add_timestamped_log(&format!(
                                             "Cannot trigger workflow '{}' in {} state",
                                             workflow_name, status_text
                                         ));
 
                                         // Add hint about using reset
                                         if needs_reset_hint {
-                                            let timestamp =
-                                                Local::now().format("%H:%M:%S").to_string();
-                                            app.logs.push(format!(
-                                                "[{}] Hint: Press 'Shift+R' to reset the workflow status and allow triggering",
-                                                timestamp
-                                            ));
+                                            app.add_timestamped_log(
+                                                "Hint: Press 'Shift+R' to reset the workflow status and allow triggering",
+                                            );
                                         }
 
                                         wrkflw_logging::warning(&format!(
@@ -610,20 +604,18 @@ fn run_tui_event_loop(
                                     }
                                 }
                             } else {
-                                app.logs.push("No workflow selected to trigger".to_string());
+                                app.add_timestamped_log("No workflow selected to trigger");
                                 wrkflw_logging::warning("No workflow selected to trigger");
                             }
                         } else if app.running {
-                            app.logs.push(
-                                "Cannot trigger workflow while another operation is in progress"
-                                    .to_string(),
+                            app.add_timestamped_log(
+                                "Cannot trigger workflow while another operation is in progress",
                             );
                             wrkflw_logging::warning(
                                 "Cannot trigger workflow while another operation is in progress",
                             );
                         } else if app.selected_tab != TAB_WORKFLOWS {
-                            app.logs
-                                .push("Switch to Workflows tab to trigger a workflow".to_string());
+                            app.add_timestamped_log("Switch to Workflows tab to trigger a workflow");
                             wrkflw_logging::warning(
                                 "Switch to Workflows tab to trigger a workflow",
                             );

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -30,18 +30,18 @@ pub struct App {
     pub execution_queue: Vec<QueuedExecution>, // Workflows queued for execution
     pub current_execution: Option<usize>,
     logs: Vec<String>, // Overall execution logs — private so every mutation routes through `add_log`
-    pub log_scroll: usize,                       // Scrolling position for logs
-    pub job_list_state: ListState,               // For viewing job details
-    pub detailed_view: bool,                     // Whether we're in detailed view mode
-    pub step_list_state: ListState,              // For selecting steps in detailed view
-    pub step_table_state: TableState,            // For the steps table in detailed view
-    pub last_tick: Instant,                      // For UI animations and updates
-    pub tick_rate: Duration,                     // How often to update the UI
-    pub spinner_frame: usize,                    // Current spinner animation frame
-    pub tx: mpsc::Sender<ExecutionResultMsg>,    // Channel for async communication
-    pub status_message: Option<String>,          // Temporary status message to display
+    pub log_scroll: usize, // Scrolling position for logs
+    pub job_list_state: ListState, // For viewing job details
+    pub detailed_view: bool, // Whether we're in detailed view mode
+    pub step_list_state: ListState, // For selecting steps in detailed view
+    pub step_table_state: TableState, // For the steps table in detailed view
+    pub last_tick: Instant, // For UI animations and updates
+    pub tick_rate: Duration, // How often to update the UI
+    pub spinner_frame: usize, // Current spinner animation frame
+    pub tx: mpsc::Sender<ExecutionResultMsg>, // Channel for async communication
+    pub status_message: Option<String>, // Temporary status message to display
     pub status_message_severity: StatusSeverity, // Severity of the current status message
-    pub status_message_time: Option<Instant>,    // When the message was set
+    pub status_message_time: Option<Instant>, // When the message was set
 
     // Search and filter functionality
     pub log_search_query: String, // Current search query for logs
@@ -867,7 +867,6 @@ impl App {
                         self.add_log(format!("  parse error: {}: {}", path.display(), reason));
                     }
                 }
-
             }
             DiffFilterOutcome::Failure(reason) => {
                 for workflow in &mut self.workflows {
@@ -2786,7 +2785,11 @@ mod tests {
         let revision_before = app.logs_revision;
         app.add_timestamped_log("one more while at cap");
 
-        assert_eq!(app.logs.len(), len_before, "len must stay pinned at the cap");
+        assert_eq!(
+            app.logs.len(),
+            len_before,
+            "len must stay pinned at the cap"
+        );
         assert_ne!(
             app.logs_revision, revision_before,
             "revision must advance even though len did not"

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -29,7 +29,7 @@ pub struct App {
     pub show_action_messages: bool,
     pub execution_queue: Vec<QueuedExecution>, // Workflows queued for execution
     pub current_execution: Option<usize>,
-    pub logs: Vec<String>,                       // Overall execution logs
+    logs: Vec<String>, // Overall execution logs — private so every mutation routes through `add_log`
     pub log_scroll: usize,                       // Scrolling position for logs
     pub job_list_state: ListState,               // For viewing job details
     pub detailed_view: bool,                     // Whether we're in detailed view mode
@@ -58,6 +58,7 @@ pub struct App {
     pub processed_logs: Vec<ProcessedLogEntry>,
     pub logs_need_update: bool,        // Flag to trigger log processing
     pub last_system_logs_count: usize, // Track system log changes
+    logs_revision: u64, // Bumped on every log/search/filter change; `logs.len()` goes stale at the cap
 
     // Job selection mode
     pub job_selection_mode: bool, // Are we viewing jobs of a workflow?
@@ -473,6 +474,7 @@ impl App {
             processed_logs: Vec::new(),
             logs_need_update: true,
             last_system_logs_count: 0,
+            logs_revision: 0,
 
             // Job selection mode
             job_selection_mode: false,
@@ -866,23 +868,12 @@ impl App {
                     }
                 }
 
-                // Ad-hoc `self.logs.push(...)` skips the cap that
-                // `add_log` / `mark_logs_for_update` normally enforce.
-                // A single large evaluation could push dozens of
-                // rows + warnings + parse failures all at once, and
-                // without this trim the buffer can temporarily exceed
-                // `LOG_BUFFER_CAP` until the next render pass happens
-                // to route through `mark_logs_for_update`. Mirror the
-                // `add_log` discipline here so the cap invariant is
-                // reasserted immediately.
-                self.trim_logs_to_cap();
             }
             DiffFilterOutcome::Failure(reason) => {
                 for workflow in &mut self.workflows {
                     workflow.trigger_match = None;
                 }
                 self.add_timestamped_log(&format!("Diff filter: evaluation failed — {}", reason));
-                self.trim_logs_to_cap();
             }
         }
     }
@@ -894,10 +885,9 @@ impl App {
         } else {
             "normal"
         };
-        let timestamp = Local::now().format("%H:%M:%S").to_string();
-        self.logs
-            .push(format!("[{}] Switched to {} mode", timestamp, mode));
-        wrkflw_logging::info(&format!("Switched to {} mode", mode));
+        let msg = format!("Switched to {} mode", mode);
+        self.add_timestamped_log(&msg);
+        wrkflw_logging::info(&msg);
     }
 
     pub fn runtime_type_name(&self) -> &str {
@@ -1110,9 +1100,7 @@ impl App {
 
             // Log only once at the beginning - don't initialize execution details here
             // since that will happen in start_next_workflow_execution
-            let timestamp = Local::now().format("%H:%M:%S").to_string();
-            self.logs
-                .push(format!("[{}] Starting workflow execution...", timestamp));
+            self.add_timestamped_log("Starting workflow execution...");
             wrkflw_logging::info("Starting workflow execution...");
         }
     }
@@ -1124,11 +1112,7 @@ impl App {
         result: Result<(Vec<wrkflw_executor::JobResult>, ()), String>,
     ) {
         if workflow_idx >= self.workflows.len() {
-            let timestamp = Local::now().format("%H:%M:%S").to_string();
-            self.logs.push(format!(
-                "[{}] Error: Invalid workflow index received",
-                timestamp
-            ));
+            self.add_timestamped_log("Error: Invalid workflow index received");
             wrkflw_logging::error("Invalid workflow index received in process_execution_result");
             return;
         }
@@ -1210,27 +1194,17 @@ impl App {
         match result {
             Ok(_) => {
                 workflow.status = WorkflowStatus::Success;
-                let timestamp = Local::now().format("%H:%M:%S").to_string();
-                self.logs.push(format!(
-                    "[{}] Workflow '{}' completed successfully!",
-                    timestamp, workflow.name
-                ));
-                wrkflw_logging::info(&format!(
-                    "[{}] Workflow '{}' completed successfully!",
-                    timestamp, workflow.name
-                ));
+                // `wrkflw_logging` stamps its own [HH:MM:SS] prefix,
+                // so it gets the bare message.
+                let msg = format!("Workflow '{}' completed successfully!", workflow.name);
+                self.add_timestamped_log(&msg);
+                wrkflw_logging::info(&msg);
             }
             Err(e) => {
                 workflow.status = WorkflowStatus::Failed;
-                let timestamp = Local::now().format("%H:%M:%S").to_string();
-                self.logs.push(format!(
-                    "[{}] Workflow '{}' failed: {}",
-                    timestamp, workflow.name, e
-                ));
-                wrkflw_logging::error(&format!(
-                    "[{}] Workflow '{}' failed: {}",
-                    timestamp, workflow.name, e
-                ));
+                let msg = format!("Workflow '{}' failed: {}", workflow.name, e);
+                self.add_timestamped_log(&msg);
+                wrkflw_logging::error(&msg);
             }
         }
 
@@ -1620,25 +1594,19 @@ impl App {
                 let workflow = &self.workflows[selected_idx];
 
                 if workflow.name.is_empty() {
-                    let timestamp = Local::now().format("%H:%M:%S").to_string();
-                    self.logs
-                        .push(format!("[{}] Error: Invalid workflow selection", timestamp));
+                    self.add_timestamped_log("Error: Invalid workflow selection");
                     wrkflw_logging::error(
                         "Invalid workflow selection in trigger_selected_workflow",
                     );
                     return;
                 }
 
-                // Set up background task to execute the workflow via GitHub Actions REST API
-                let timestamp = Local::now().format("%H:%M:%S").to_string();
-                self.logs.push(format!(
-                    "[{}] Triggering workflow: {}",
-                    timestamp, workflow.name
-                ));
-                wrkflw_logging::info(&format!("Triggering workflow: {}", workflow.name));
-
                 // Clone necessary values for the async task
                 let workflow_name = workflow.name.clone();
+
+                // Set up background task to execute the workflow via GitHub Actions REST API
+                self.add_timestamped_log(&format!("Triggering workflow: {}", workflow_name));
+                wrkflw_logging::info(&format!("Triggering workflow: {}", workflow_name));
                 let tx_clone = self.tx.clone();
 
                 // Set this tab as the current execution to ensure it shows in the Execution tab
@@ -1672,14 +1640,11 @@ impl App {
                     }
                 });
             } else {
-                let timestamp = Local::now().format("%H:%M:%S").to_string();
-                self.logs
-                    .push(format!("[{}] No workflow selected to trigger", timestamp));
+                self.add_timestamped_log("No workflow selected to trigger");
                 wrkflw_logging::warning("No workflow selected to trigger");
             }
         } else {
-            self.logs
-                .push("No workflow selected to trigger".to_string());
+            self.add_timestamped_log("No workflow selected to trigger");
             wrkflw_logging::warning("No workflow selected to trigger");
         }
     }
@@ -1688,24 +1653,21 @@ impl App {
     pub fn reset_workflow_status(&mut self) {
         // Log whether a selection exists
         if self.workflow_list_state.selected().is_none() {
-            let timestamp = Local::now().format("%H:%M:%S").to_string();
-            self.logs.push(format!(
-                "[{}] Debug: No workflow selected for reset",
-                timestamp
-            ));
+            self.add_timestamped_log("Debug: No workflow selected for reset");
             wrkflw_logging::warning("No workflow selected for reset");
             return;
         }
 
         if let Some(idx) = self.workflow_list_state.selected() {
             if idx < self.workflows.len() {
-                let workflow = &mut self.workflows[idx];
                 // Log before status
-                let timestamp = Local::now().format("%H:%M:%S").to_string();
-                self.logs.push(format!(
-                    "[{}] Debug: Attempting to reset workflow '{}' from {:?} state",
-                    timestamp, workflow.name, workflow.status
-                ));
+                let attempt_msg = format!(
+                    "Debug: Attempting to reset workflow '{}' from {:?} state",
+                    self.workflows[idx].name, self.workflows[idx].status
+                );
+                self.add_timestamped_log(&attempt_msg);
+
+                let workflow = &mut self.workflows[idx];
 
                 // Debug: Reset unconditionally for testing
                 // if workflow.status != WorkflowStatus::Running {
@@ -1725,15 +1687,12 @@ impl App {
                 // Clear execution details to reset all state
                 workflow.execution_details = None;
 
-                let timestamp = Local::now().format("%H:%M:%S").to_string();
-                self.logs.push(format!(
-                    "[{}] Reset workflow '{}' from {} state to NotStarted - status is now {:?}",
-                    timestamp, workflow.name, old_status, workflow.status
-                ));
-                wrkflw_logging::info(&format!(
+                let reset_msg = format!(
                     "Reset workflow '{}' from {} state to NotStarted - status is now {:?}",
                     workflow.name, old_status, workflow.status
-                ));
+                );
+                self.add_timestamped_log(&reset_msg);
+                wrkflw_logging::info(&reset_msg);
 
                 // Set a success status message
                 self.set_success_message(format!("Workflow '{}' has been reset!", workflow_name));
@@ -1747,7 +1706,7 @@ impl App {
             search_query: self.log_search_query.clone(),
             filter_level: self.log_filter_level.clone(),
             app_logs: self.logs.clone(),
-            app_logs_count: self.logs.len(),
+            app_logs_revision: self.logs_revision,
             system_logs_count: wrkflw_logging::get_logs().len(),
         };
 
@@ -1783,17 +1742,21 @@ impl App {
         }
     }
 
-    /// Trigger log processing when search/filter changes.
+    /// Trigger log processing when the logs or the search/filter
+    /// settings change.
     ///
-    /// Also enforces the log buffer cap so ad-hoc `self.logs.push(...)`
-    /// sites — which are sprinkled throughout the codebase for
-    /// historical reasons — don't need to each remember to call
-    /// [`trim_logs_to_cap`]. Every log mutation eventually routes
-    /// through `mark_logs_for_update` (that's what makes the logs
-    /// actually render), so trimming here is the single
-    /// unavoidable choke point.
+    /// This is the single choke point for the log pipeline: every
+    /// mutation routes through here (`logs` is private, so pushes go
+    /// via [`add_log`], and the search/filter setters call this
+    /// directly). It enforces the buffer cap and bumps the revision
+    /// the background processor uses for change detection.
     pub fn mark_logs_for_update(&mut self) {
         self.trim_logs_to_cap();
+        // Bump the revision AFTER trimming so the processor sees one
+        // revision per mutation. `logs.len()` cannot serve as the
+        // change signal: once the buffer is at LOG_BUFFER_CAP the
+        // trim keeps len constant while content still changes.
+        self.logs_revision = self.logs_revision.wrapping_add(1);
         self.logs_need_update = true;
         self.request_log_processing_update();
     }
@@ -1818,8 +1781,7 @@ impl App {
     /// Add a log entry and trigger log processing update
     pub fn add_log(&mut self, message: String) {
         self.logs.push(message);
-        self.trim_logs_to_cap();
-        self.mark_logs_for_update();
+        self.mark_logs_for_update(); // trims to the cap and bumps the revision
     }
 
     /// Add a formatted log entry with timestamp and trigger log processing update
@@ -1859,15 +1821,14 @@ impl App {
     const LOG_BUFFER_CAP: usize = 5000;
 
     /// Enforce [`LOG_BUFFER_CAP`] by dropping the oldest entries
-    /// until the buffer is within bounds. Called from every
-    /// [`add_log`] path AND from [`trim_logs_to_cap`] so ad-hoc
-    /// `self.logs.push(...)` sites can opt into the cap by calling
-    /// this once after pushing.
+    /// until the buffer is within bounds. Called from
+    /// [`mark_logs_for_update`], which every log mutation routes
+    /// through now that `logs` is private.
     ///
     /// Uses `drain(0..N)` instead of rebuilding the vec so the tail
     /// entries don't get re-cloned; the operation is O(n) in the
     /// number of *dropped* entries, which is zero on the fast path.
-    pub fn trim_logs_to_cap(&mut self) {
+    fn trim_logs_to_cap(&mut self) {
         if self.logs.len() > Self::LOG_BUFFER_CAP {
             let excess = self.logs.len() - Self::LOG_BUFFER_CAP;
             self.logs.drain(0..excess);
@@ -2778,11 +2739,11 @@ mod tests {
     #[test]
     fn log_buffer_caps_at_configured_size() {
         // Long-running TUI sessions (especially with rapid diff-filter
-        // toggles) previously grew `logs` unbounded. The cap has to
-        // hold even when callers push directly to `self.logs` without
-        // going through `add_log`, because every render path eventually
-        // routes through `mark_logs_for_update`. Verify the cap kicks
-        // in on both shapes.
+        // toggles) previously grew `logs` unbounded. `logs` is private
+        // now, so production code can only push via `add_log`, but the
+        // cap is enforced in `mark_logs_for_update` — verify it holds
+        // even for direct pushes (possible only here, inside the state
+        // module) once that choke point runs.
         let mut app = make_app();
         // Start from a clean slate so the setup-time log lines do not
         // pollute the size assertion.
@@ -2804,6 +2765,31 @@ mod tests {
                 .contains(&format!("{}", App::LOG_BUFFER_CAP + 199)),
             "newest entry must survive the drain, got {:?}",
             app.logs.last()
+        );
+    }
+
+    #[test]
+    fn log_revision_advances_while_len_is_pinned_at_cap() {
+        // Once the buffer sits at LOG_BUFFER_CAP, every push drains one
+        // old entry, so `logs.len()` never changes again. The background
+        // processor keys its change detection off `logs_revision` for
+        // exactly this reason — a length-based signal froze the Logs tab
+        // the moment the cap was reached.
+        let mut app = make_app();
+        app.logs.clear();
+        for i in 0..App::LOG_BUFFER_CAP {
+            app.logs.push(format!("line {}", i));
+        }
+        app.mark_logs_for_update();
+
+        let len_before = app.logs.len();
+        let revision_before = app.logs_revision;
+        app.add_timestamped_log("one more while at cap");
+
+        assert_eq!(app.logs.len(), len_before, "len must stay pinned at the cap");
+        assert_ne!(
+            app.logs_revision, revision_before,
+            "revision must advance even though len did not"
         );
     }
 

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -572,7 +572,7 @@ impl App {
             .unwrap_or(0);
         let next_idx = (current_idx + 1) % ROTATION.len();
         let next = ROTATION[next_idx].to_string();
-        self.logs.push(format!(
+        self.add_timestamped_log(&format!(
             "Diff filter event: {} -> {}",
             self.diff_filter_event, next
         ));
@@ -2124,12 +2124,11 @@ impl App {
         let curl = self.trigger_curl_preview();
         let mut lines = curl.lines();
         if let Some(first) = lines.next() {
-            self.logs.push(format!("curl: {}", first));
+            self.add_timestamped_log(&format!("curl: {}", first));
         }
         for rest in lines {
-            self.logs.push(format!("curl: {}", rest));
+            self.add_timestamped_log(&format!("curl: {}", rest));
         }
-        self.trim_logs_to_cap();
     }
 
     /// Exposed as `pub` so the Trigger view can render the same string
@@ -2254,13 +2253,12 @@ impl App {
             .cloned()
             .collect();
         let platform = self.trigger_platform;
-        self.logs.push(format!(
+        self.add_timestamped_log(&format!(
             "Dispatching {} to {:?} (branch: {})",
             wf_name_raw,
             platform,
             branch.as_deref().unwrap_or("<default>")
         ));
-        self.trim_logs_to_cap();
 
         // Flip the in-flight flag BEFORE the spawn so a rapid
         // second Enter — dispatched from the same UI tick before
@@ -2335,7 +2333,6 @@ impl App {
     /// `try_recv` so the call never blocks.
     pub fn drain_trigger_outcomes(&mut self) {
         let mut last: Option<DispatchOutcome> = None;
-        let mut drained = 0usize;
         while let Ok(outcome) = self.trigger_outcome_rx.try_recv() {
             // Log every outcome so the Logs tab is the durable
             // record — the status bar can only show one line.
@@ -2352,7 +2349,7 @@ impl App {
                     e
                 ),
             };
-            self.logs.push(line);
+            self.add_timestamped_log(&line);
             // Prefer the most recent error over any later success,
             // and the most recent outcome otherwise.
             match (&last, &outcome.result) {
@@ -2361,10 +2358,6 @@ impl App {
                 }
                 _ => last = Some(outcome),
             }
-            drained += 1;
-        }
-        if drained > 0 {
-            self.trim_logs_to_cap();
         }
         if let Some(outcome) = last {
             match outcome.result {
@@ -2775,6 +2768,13 @@ mod tests {
         app
     }
 
+    /// Run a log line through the real renderer-side parser and return
+    /// the timestamp it extracts — `??:??:??` means the line is missing
+    /// the `[HH:MM:SS]` prefix the Execution/Logs tabs depend on.
+    fn parsed_timestamp(line: &str) -> String {
+        crate::log_processor::LogProcessor::process_log_entry(line, "").timestamp
+    }
+
     #[test]
     fn log_buffer_caps_at_configured_size() {
         // Long-running TUI sessions (especially with rapid diff-filter
@@ -2823,6 +2823,73 @@ mod tests {
             app.diff_filter_event, "push",
             "rotation must wrap after exhausting the known-event list"
         );
+    }
+
+    #[test]
+    fn cycle_diff_filter_event_logs_timestamped_line() {
+        let mut app = make_app();
+        app.logs.clear();
+        app.cycle_diff_filter_event();
+        let line = app
+            .logs
+            .iter()
+            .find(|l| l.contains("Diff filter event: push -> pull_request"))
+            .expect("cycling must log the event transition");
+        assert_ne!(
+            parsed_timestamp(line),
+            "??:??:??",
+            "diff filter event line must carry a timestamp, got {:?}",
+            line
+        );
+    }
+
+    #[test]
+    fn trigger_tab_copy_curl_logs_timestamped_lines() {
+        let mut app = make_app();
+        app.logs.clear();
+        // No repo cache: the preview falls back to placeholder values,
+        // which is fine — only the log-line shape matters here.
+        app.trigger_tab_copy_curl();
+        assert!(!app.logs.is_empty(), "copy-curl must log the recipe");
+        for line in &app.logs {
+            assert!(line.contains("curl:"), "unexpected line {:?}", line);
+            assert_ne!(
+                parsed_timestamp(line),
+                "??:??:??",
+                "every curl line must carry a timestamp, got {:?}",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn drain_trigger_outcomes_logs_timestamped_lines() {
+        let mut app = make_app();
+        app.logs.clear();
+        app.trigger_outcome_tx
+            .send(DispatchOutcome {
+                platform: TriggerPlatform::Github,
+                workflow: "ci".into(),
+                result: Ok(()),
+            })
+            .unwrap();
+        app.trigger_outcome_tx
+            .send(DispatchOutcome {
+                platform: TriggerPlatform::Gitlab,
+                workflow: "deploy".into(),
+                result: Err("401 Unauthorized".into()),
+            })
+            .unwrap();
+        app.drain_trigger_outcomes();
+        assert_eq!(app.logs.len(), 2, "both outcomes must be logged");
+        for line in &app.logs {
+            assert_ne!(
+                parsed_timestamp(line),
+                "??:??:??",
+                "dispatch outcome line must carry a timestamp, got {:?}",
+                line
+            );
+        }
     }
 
     #[test]

--- a/crates/ui/src/handlers/workflow.rs
+++ b/crates/ui/src/handlers/workflow.rs
@@ -477,7 +477,9 @@ pub fn start_next_workflow_execution(
                 };
 
                 if !is_docker_available {
-                    app.add_timestamped_log("Docker is not available. Using emulation mode instead.");
+                    app.add_timestamped_log(
+                        "Docker is not available. Using emulation mode instead.",
+                    );
                     wrkflw_logging::warning(
                         "Docker is not available. Using emulation mode instead.",
                     );
@@ -501,7 +503,9 @@ pub fn start_next_workflow_execution(
                 };
 
                 if !is_podman_available {
-                    app.add_timestamped_log("Podman is not available. Using emulation mode instead.");
+                    app.add_timestamped_log(
+                        "Podman is not available. Using emulation mode instead.",
+                    );
                     wrkflw_logging::warning(
                         "Podman is not available. Using emulation mode instead.",
                     );

--- a/crates/ui/src/handlers/workflow.rs
+++ b/crates/ui/src/handlers/workflow.rs
@@ -449,13 +449,11 @@ pub fn start_next_workflow_execution(
 
         // Log whether verbose mode is enabled
         if verbose {
-            app.logs
-                .push("Verbose mode: Step outputs will be displayed in full".to_string());
+            app.add_timestamped_log("Verbose mode: Step outputs will be displayed in full");
             wrkflw_logging::info("Verbose mode: Step outputs will be displayed in full");
         } else {
-            app.logs.push(
-                "Standard mode: Only step status will be shown (use --verbose for full output)"
-                    .to_string(),
+            app.add_timestamped_log(
+                "Standard mode: Only step status will be shown (use --verbose for full output)",
             );
             wrkflw_logging::info(
                 "Standard mode: Only step status will be shown (use --verbose for full output)",
@@ -479,8 +477,7 @@ pub fn start_next_workflow_execution(
                 };
 
                 if !is_docker_available {
-                    app.logs
-                        .push("Docker is not available. Using emulation mode instead.".to_string());
+                    app.add_timestamped_log("Docker is not available. Using emulation mode instead.");
                     wrkflw_logging::warning(
                         "Docker is not available. Using emulation mode instead.",
                     );
@@ -504,8 +501,7 @@ pub fn start_next_workflow_execution(
                 };
 
                 if !is_podman_available {
-                    app.logs
-                        .push("Podman is not available. Using emulation mode instead.".to_string());
+                    app.add_timestamped_log("Podman is not available. Using emulation mode instead.");
                     wrkflw_logging::warning(
                         "Podman is not available. Using emulation mode instead.",
                     );
@@ -629,9 +625,7 @@ pub fn start_next_workflow_execution(
         });
     } else {
         app.running = false;
-        let timestamp = Local::now().format("%H:%M:%S").to_string();
-        app.logs
-            .push(format!("[{}] All workflows completed execution", timestamp));
+        app.add_timestamped_log("All workflows completed execution");
         wrkflw_logging::info("All workflows completed execution");
     }
 }

--- a/crates/ui/src/log_processor.rs
+++ b/crates/ui/src/log_processor.rs
@@ -35,9 +35,13 @@ impl ProcessedLogEntry {
 pub struct LogProcessingRequest {
     pub search_query: String,
     pub filter_level: Option<LogFilterLevel>,
-    pub app_logs: Vec<String>,    // Complete app logs
-    pub app_logs_count: usize,    // To detect changes in app logs
-    pub system_logs_count: usize, // To detect changes in system logs
+    pub app_logs: Vec<String>, // Complete app logs
+    // Change signal for app logs AND search/filter edits. A revision
+    // counter rather than `app_logs.len()`: once the app's buffer
+    // hits its cap, pushes stop changing the length (one old entry is
+    // dropped per new one), so a count would freeze the display.
+    pub app_logs_revision: u64,
+    pub system_logs_count: usize, // To detect changes in system logs (unbounded, so len works)
 }
 
 /// Response with processed logs
@@ -94,7 +98,9 @@ impl LogProcessor {
         let mut last_request: Option<LogProcessingRequest> = None;
         let mut last_processed_time = Instant::now();
         let mut cached_logs: Vec<String> = Vec::new();
-        let mut cached_app_logs_count = 0;
+        // u64::MAX so the first request always mismatches — the app's
+        // revision starts at 0.
+        let mut cached_app_logs_revision = u64::MAX;
         let mut cached_system_logs_count = 0;
 
         loop {
@@ -110,17 +116,17 @@ impl LogProcessor {
 
             if let Some(ref req) = last_request {
                 let should_process = last_processed_time.elapsed() > Duration::from_millis(50)
-                    && (cached_app_logs_count != req.app_logs_count
+                    && (cached_app_logs_revision != req.app_logs_revision
                         || cached_system_logs_count != req.system_logs_count
                         || cached_logs.is_empty());
 
                 if should_process {
-                    if cached_app_logs_count != req.app_logs_count
+                    if cached_app_logs_revision != req.app_logs_revision
                         || cached_system_logs_count != req.system_logs_count
                         || cached_logs.is_empty()
                     {
                         cached_logs = Self::get_combined_logs(&req.app_logs);
-                        cached_app_logs_count = req.app_logs_count;
+                        cached_app_logs_revision = req.app_logs_revision;
                         cached_system_logs_count = req.system_logs_count;
                     }
 

--- a/crates/ui/src/log_processor.rs
+++ b/crates/ui/src/log_processor.rs
@@ -191,7 +191,7 @@ impl LogProcessor {
     }
 
     /// Process a single log entry into display format
-    fn process_log_entry(log_line: &str, search_query: &str) -> ProcessedLogEntry {
+    pub(crate) fn process_log_entry(log_line: &str, search_query: &str) -> ProcessedLogEntry {
         // Extract timestamp from log format [HH:MM:SS]
         let timestamp = if log_line.starts_with('[') && log_line.contains(']') {
             let end = log_line.find(']').unwrap_or(0);


### PR DESCRIPTION
## Summary

Follow-up to #116, which routed most app-generated TUI log messages through `add_timestamped_log` but missed four bare `self.logs.push(...)` sites. Those lines lack the `[HH:MM:SS]` prefix the log renderer parses, so they still displayed `??:??:??` in the Execution/Logs tabs.

## Changes

- Convert the four remaining sites in `crates/ui/src/app/state.rs` to `add_timestamped_log`:
  - `cycle_diff_filter_event` — "Diff filter event: {} -> {}"
  - `trigger_tab_copy_curl` — "curl: ..." recipe lines
  - `trigger_dispatch` — "Dispatching {} to {:?} (branch: {})"
  - `drain_trigger_outcomes` — "Dispatched ..." / "Dispatch ... failed: ..."
- Remove the three `trim_logs_to_cap()` calls (and the `drained` counter gating one of them) that only existed because the bare pushes bypassed `add_log`'s built-in trim.
- Widen `LogProcessor::process_log_entry` to `pub(crate)` so state tests can assert end-to-end behavior.

## Testing

Three new tests call the real methods and run the actual appended log lines through the real parser, asserting the extracted timestamp is not `??:??:??`. The `trigger_dispatch` site is not exercised end-to-end (it `tokio::spawn`s a real dispatch) and is covered by pattern parity with the tested sites.

`cargo test -p wrkflw-ui`: 57 passed. `cargo clippy -p wrkflw-ui --all-targets`: clean.