### PR TITLE
fix(executor): skip a job when a job it needs did not succeed

### DIFF
--- a/crates/executor/src/engine.rs
+++ b/crates/executor/src/engine.rs
@@ -222,9 +222,50 @@ async fn execute_github_workflow(
     let mut all_job_results: HashMap<String, String> = HashMap::new();
 
     for job_batch in execution_plan {
+        // GitHub Actions: a job that declares `needs:` runs only if every needed
+        // job succeeded. If any needed job failed or was itself skipped, this job
+        // is skipped too, and its own dependents cascade. `resolve_dependencies`
+        // only orders the batches — it never enforces this — so do it here, before
+        // the batch runs. A job carrying an explicit `if:` is left for
+        // `execute_single_job` to evaluate: `if: always()` / `if: failure()` may
+        // deliberately opt back in.
+        let mut runnable: Vec<String> = Vec::with_capacity(job_batch.len());
+        for job_name in &job_batch {
+            match workflow
+                .jobs
+                .get(job_name)
+                .and_then(|job| job_blocked_by_needs(job, &all_job_results))
+            {
+                Some(reason) => {
+                    wrkflw_logging::info(&format!(
+                        "{} Skipping job '{}': {}",
+                        wrkflw_logging::symbols::SKIPPED,
+                        job_name,
+                        reason,
+                    ));
+                    let skipped = JobResult {
+                        name: job_name.clone(),
+                        canonical_name: job_name.clone(),
+                        status: JobStatus::Skipped,
+                        steps: Vec::new(),
+                        logs: String::new(),
+                        outputs: HashMap::new(),
+                    };
+                    all_job_results
+                        .insert(skipped.canonical_name.clone(), skipped.status.to_string());
+                    all_job_outputs.insert(skipped.canonical_name.clone(), skipped.outputs.clone());
+                    results.push(skipped);
+                }
+                None => runnable.push(job_name.clone()),
+            }
+        }
+        if runnable.is_empty() {
+            continue;
+        }
+
         // Execute jobs in parallel if they don't depend on each other
         let job_results = execute_job_batch(
-            &job_batch,
+            &runnable,
             &workflow,
             runtime.as_ref(),
             &env_context,
@@ -303,6 +344,32 @@ async fn execute_github_workflow(
             None
         },
     })
+}
+
+/// GitHub Actions `needs:` failure semantics: with no explicit `if:`, a job runs
+/// only when every job it needs succeeded. Returns `Some(reason)` when the job
+/// must be skipped because a needed job failed or was itself skipped, `None` when
+/// it may run. Jobs with an `if:` are always allowed through here —
+/// `execute_single_job` evaluates the condition and can opt back in on failure.
+fn job_blocked_by_needs(job: &Job, all_job_results: &HashMap<String, String>) -> Option<String> {
+    if job.if_condition.is_some() {
+        return None;
+    }
+    let needs = job.needs.as_ref()?;
+    for needed in needs {
+        match all_job_results.get(needed).map(String::as_str) {
+            // "success", or not-yet-recorded (a filtered target-job plan can omit
+            // an upstream job) — neither blocks.
+            Some("success") | None => {}
+            Some(other) => {
+                return Some(format!(
+                    "needed job '{}' did not succeed ({})",
+                    needed, other
+                ));
+            }
+        }
+    }
+    None
 }
 
 /// Execute a GitLab CI/CD pipeline locally

--- a/crates/wrkflw/tests/needs_failure_propagation_test.rs
+++ b/crates/wrkflw/tests/needs_failure_propagation_test.rs
@@ -1,0 +1,184 @@
+use std::fs;
+use tempfile::tempdir;
+use wrkflw_lib::executor::engine::{
+    execute_workflow, ExecutionConfig, ExecutionResult, JobStatus, RuntimeType,
+};
+
+fn write_file(path: &std::path::Path, content: &str) {
+    fs::write(path, content).expect("failed to write file");
+}
+
+fn emulation_cfg() -> ExecutionConfig {
+    ExecutionConfig {
+        runtime_type: RuntimeType::Emulation,
+        verbose: false,
+        preserve_containers_on_failure: false,
+        secrets_config: None,
+        show_action_messages: false,
+        target_job: None,
+    }
+}
+
+fn status_of<'a>(result: &'a ExecutionResult, job: &str) -> &'a str {
+    let jr = result
+        .jobs
+        .iter()
+        .find(|j| j.canonical_name == job)
+        .unwrap_or_else(|| {
+            let names: Vec<&str> = result
+                .jobs
+                .iter()
+                .map(|j| j.canonical_name.as_str())
+                .collect();
+            panic!("job '{}' not in results: {:?}", job, names)
+        });
+    match jr.status {
+        JobStatus::Success => "success",
+        JobStatus::Failure => "failure",
+        JobStatus::Skipped => "skipped",
+    }
+}
+
+/// A job whose `needs:` dependency failed must be skipped, not run.
+#[tokio::test]
+async fn dependent_job_is_skipped_when_need_fails() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ci.yml");
+    write_file(
+        &path,
+        r#"
+name: CI
+on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    steps:
+      - run: echo "should not run"
+"#,
+    );
+
+    let result = execute_workflow(&path, emulation_cfg())
+        .await
+        .expect("workflow execution completed");
+
+    assert_eq!(status_of(&result, "deploy"), "failure");
+    assert_eq!(
+        status_of(&result, "e2e"),
+        "skipped",
+        "e2e must be skipped because deploy failed"
+    );
+}
+
+/// The skip cascades: a job that needs a skipped job is skipped too.
+#[tokio::test]
+async fn skip_cascades_through_the_needs_chain() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ci.yml");
+    write_file(
+        &path,
+        r#"
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - run: echo hi
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - run: echo hi
+"#,
+    );
+
+    let result = execute_workflow(&path, emulation_cfg())
+        .await
+        .expect("workflow execution completed");
+
+    assert_eq!(status_of(&result, "build"), "failure");
+    assert_eq!(status_of(&result, "test"), "skipped");
+    assert_eq!(status_of(&result, "publish"), "skipped");
+}
+
+/// An explicit `if:` opts a dependent job back in even when its need failed.
+#[tokio::test]
+async fn explicit_if_condition_still_runs_after_a_failed_need() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ci.yml");
+    write_file(
+        &path,
+        r#"
+name: CI
+on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+  notify:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: always()
+    steps:
+      - run: echo "report the failure"
+"#,
+    );
+
+    let result = execute_workflow(&path, emulation_cfg())
+        .await
+        .expect("workflow execution completed");
+
+    assert_eq!(status_of(&result, "deploy"), "failure");
+    assert_eq!(
+        status_of(&result, "notify"),
+        "success",
+        "notify has `if: always()` and must still run"
+    );
+}
+
+/// Independent jobs in a later batch are unaffected by an unrelated failure.
+#[tokio::test]
+async fn unrelated_jobs_still_run_after_a_failure() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ci.yml");
+    write_file(
+        &path,
+        r#"
+name: CI
+on: push
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+  b:
+    runs-on: ubuntu-latest
+    needs: [a]
+    steps:
+      - run: echo hi
+  c:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo independent
+"#,
+    );
+
+    let result = execute_workflow(&path, emulation_cfg())
+        .await
+        .expect("workflow execution completed");
+
+    assert_eq!(status_of(&result, "a"), "failure");
+    assert_eq!(status_of(&result, "b"), "skipped");
+    assert_eq!(status_of(&result, "c"), "success");
+}


### PR DESCRIPTION
Fixes #125.

### Problem

A job that declares `needs: [x]` runs even when job `x` failed. In
`execute_github_workflow` the batch loop runs every batch unconditionally —
`needs:` drives ordering and `needs.*` context but never failure propagation,
so GitHub Actions' rule ("a dependent job runs only if every job in `needs:`
succeeded, unless it sets its own `if:`") is not enforced.

### Change

Before running each batch, partition it into runnable jobs and jobs blocked by
a failed or skipped `needs:` entry. A blocked job is recorded as
`JobStatus::Skipped` (same `JobResult` shape the existing `if:` skip produces)
and written into `all_job_results` / `all_job_outputs`, so the skip **cascades**
to its own dependents.

A job that carries an explicit `if:` is passed through to `execute_single_job`
unchanged, so `if: always()`, `if: failure()`, etc. keep working. A `needs:`
entry absent from `all_job_results` (possible under a `--target-job` filtered
plan) is treated as non-blocking, matching current behaviour.

New helper: `job_blocked_by_needs(&Job, &HashMap<String, String>) -> Option<String>`
— returns the skip reason for the log line, or `None`.

GitLab pipelines (`execute_gitlab_pipeline`) have their own `when:` /
`allow_failure:` semantics and are untouched.

### Tests

`crates/wrkflw/tests/needs_failure_propagation_test.rs` drives a real
`EmulationRuntime` through `execute_workflow`:

| test | asserts |
|---|---|
| `dependent_job_is_skipped_when_need_fails` | `deploy` fails → `e2e` skipped |
| `skip_cascades_through_the_needs_chain` | `build` fails → `test` and `publish` both skipped |
| `explicit_if_condition_still_runs_after_a_failed_need` | `notify` with `if: always()` still runs |
| `unrelated_jobs_still_run_after_a_failure` | independent job `c` unaffected |

Existing `cargo test -p wrkflw-executor` (409) and `--test target_job_test` (3)
stay green. `cargo fmt --check` and `cargo clippy -p wrkflw-executor` clean.
