### PR TITLE
fix(ui): show real timestamps on diff-filter log lines

### DIFF
--- a/crates/executor/src/docker.rs
+++ b/crates/executor/src/docker.rs
@@ -80,7 +80,7 @@ impl DockerRuntime {
         };
 
         // Look for any key that starts with the prefix
-        for (key, _) in image_keys.iter() {
+        for key in image_keys.keys() {
             if key.starts_with(prefix) {
                 return Some(key.clone());
             }

--- a/crates/executor/src/podman.rs
+++ b/crates/executor/src/podman.rs
@@ -80,7 +80,7 @@ impl PodmanRuntime {
         };
 
         // Look for any key that starts with the prefix
-        for (key, _) in image_keys.iter() {
+        for key in image_keys.keys() {
             if key.starts_with(prefix) {
                 return Some(key.clone());
             }

--- a/crates/executor/src/workflow_commands.rs
+++ b/crates/executor/src/workflow_commands.rs
@@ -130,10 +130,9 @@ fn parse_command_line(line: &str) -> Option<WorkflowCommand> {
     let rest = line.strip_prefix("::").unwrap_or(line);
 
     // Find the second "::" that separates command+params from the message
-    let (cmd_part, raw_message) = if let Some(idx) = rest.find("::") {
+    let (cmd_part, raw_message) = {
+        let idx = rest.find("::")?;
         (&rest[..idx], rest[idx + 2..].to_string())
-    } else {
-        return None;
     };
 
     // Decode percent-encoded values in the message

--- a/crates/logging/src/symbols.rs
+++ b/crates/logging/src/symbols.rs
@@ -30,6 +30,11 @@ pub const CHECKBOX_ON: &str = "[\u{2714}]"; // [✔]
 pub const CHECKBOX_OFF: &str = "[ ]";
 pub const TAB_DIVIDER: &str = " \u{2502} "; // │
 
+// Marks a log line as a sub-item of the line above it. A glyph rather than
+// leading whitespace because the log renderer trims the content after the
+// `[HH:MM:SS]` prefix, which erases indentation.
+pub const NESTED: &str = "\u{21B3}"; // ↳
+
 // Braille spinner frames for running animation
 pub const SPINNER: &[&str] = &[
     "\u{280B}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283C}", "\u{2834}", "\u{2826}", "\u{2827}",

--- a/crates/runtime/src/emulation.rs
+++ b/crates/runtime/src/emulation.rs
@@ -110,7 +110,7 @@ impl EmulationRuntime {
                             if let Err(e) = fs::copy(&source, &dest) {
                                 eprintln!(
                                     "Warning: Failed to copy file from {:?} to {:?}: {}",
-                                    &source, &dest, e
+                                    source, dest, e
                                 );
                             }
                         } else {
@@ -135,7 +135,7 @@ impl EmulationRuntime {
                 if let Err(e) = fs::copy(host_path, &dest) {
                     eprintln!(
                         "Warning: Failed to copy file from {:?} to {:?}: {}",
-                        host_path, &dest, e
+                        host_path, dest, e
                     );
                 }
             }

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -708,7 +708,7 @@ impl App {
 
         let event_name = self.diff_filter_event.clone();
         let activity_type = self.diff_filter_activity_type.clone();
-        self.add_log(format!(
+        self.add_timestamped_log(&format!(
             "Diff filter: evaluating triggers (simulating '{}' event)...",
             event_name
         ));
@@ -890,8 +890,18 @@ impl App {
                         "Diff filter: {} warning(s)",
                         warnings.len()
                     ));
+                    // Sub-items are marked with a glyph rather than
+                    // leading whitespace: `process_log_entry` trims the
+                    // content after the `[HH:MM:SS]` prefix, so an
+                    // indented line would either lose its nesting or
+                    // have to skip the timestamp entirely (it used to do
+                    // the latter, rendering `??:??:??`).
                     for w in &warnings {
-                        self.add_log(format!("  warning: {}", w));
+                        self.add_timestamped_log(&format!(
+                            "{} warning: {}",
+                            crate::theme::symbols::NESTED,
+                            w
+                        ));
                     }
                 }
 
@@ -906,7 +916,12 @@ impl App {
                         parse_failures.len()
                     ));
                     for (path, reason) in &parse_failures {
-                        self.add_log(format!("  parse error: {}: {}", path.display(), reason));
+                        self.add_timestamped_log(&format!(
+                            "{} parse error: {}: {}",
+                            crate::theme::symbols::NESTED,
+                            path.display(),
+                            reason
+                        ));
                     }
                 }
             }
@@ -2778,6 +2793,17 @@ mod tests {
         crate::log_processor::LogProcessor::process_log_entry(line, "").timestamp
     }
 
+    /// The content the log panes actually draw, after the parser strips the
+    /// `[HH:MM:SS]` prefix and trims. Leading whitespace does not survive
+    /// this, which is why nesting is carried by a glyph.
+    fn rendered_content(line: &str) -> String {
+        crate::log_processor::LogProcessor::process_log_entry(line, "")
+            .content_spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
     #[test]
     fn log_buffer_caps_at_configured_size() {
         // Long-running TUI sessions (especially with rapid diff-filter
@@ -3172,6 +3198,99 @@ mod tests {
     }
 
     #[test]
+    fn check_diff_filter_results_timestamps_nested_sub_items() {
+        // Regression: the per-warning and per-parse-error sub-items were
+        // pushed through `add_log` with two leading spaces so the log pane
+        // showed them nested under their summary line. `process_log_entry`
+        // trims the content after the `[HH:MM:SS]` prefix, so the author
+        // dropped the timestamp to keep the indentation — and every one of
+        // those lines rendered `??:??:??`. The nesting is now carried by a
+        // glyph, which survives the trim, so the timestamp can come back.
+        let mut app = make_app();
+        app.logs.clear();
+
+        let (tx, rx) = mpsc::channel();
+        app.diff_filter_rx = Some(rx);
+        app.diff_filter_active = true;
+        tx.send(DiffFilterOutcome::Success(DiffFilterReport {
+            rows: vec![(
+                PathBuf::from("ci.yml"),
+                Some(TriggerMatchStatus::Matched("matched ci".into())),
+            )],
+            parse_failures: vec![(
+                PathBuf::from("broken.yml"),
+                "Invalid glob pattern '[unclosed' under 'push.paths'".to_string(),
+            )],
+            warnings: vec![
+                "git ls-files --others failed (exit 128): fatal: unsafe repository".to_string(),
+            ],
+        }))
+        .unwrap();
+
+        app.check_diff_filter_results();
+
+        // Every line in the burst — summaries and sub-items alike — must
+        // carry a real timestamp.
+        for line in &app.logs {
+            assert_ne!(
+                parsed_timestamp(line),
+                "??:??:??",
+                "diff-filter log line must carry a timestamp, got {:?}",
+                line
+            );
+        }
+
+        let nested = crate::theme::symbols::NESTED;
+        let warning_line = app
+            .logs
+            .iter()
+            .find(|l| l.contains("git ls-files --others failed"))
+            .expect("warning sub-item must be logged");
+        let parse_line = app
+            .logs
+            .iter()
+            .find(|l| l.contains("broken.yml"))
+            .expect("parse-error sub-item must be logged");
+
+        // Sub-items are marked as nested...
+        for line in [warning_line, parse_line] {
+            assert!(
+                line.contains(nested),
+                "sub-item must carry the nesting glyph, got {:?}",
+                line
+            );
+            // ...and the glyph must survive the renderer's trim, or the
+            // nesting is invisible to the user no matter what we store.
+            let rendered = rendered_content(line);
+            assert!(
+                rendered.starts_with(nested),
+                "nesting glyph must survive the content trim, got {:?}",
+                rendered
+            );
+        }
+
+        // Summary lines are NOT nested — they are the parents.
+        let summary_lines: Vec<&String> = app
+            .logs
+            .iter()
+            .filter(|l| l.contains("warning(s)") || l.contains("failed to parse"))
+            .collect();
+        assert_eq!(
+            summary_lines.len(),
+            2,
+            "expected both summary lines, got {:?}",
+            app.logs
+        );
+        for line in summary_lines {
+            assert!(
+                !line.contains(nested),
+                "summary line must not be marked as nested, got {:?}",
+                line
+            );
+        }
+    }
+
+    #[test]
     fn check_diff_filter_results_surfaces_failure_reason_to_logs() {
         // Regression: previously, if auto_detect_context_default_base
         // errored (e.g. fresh repo with no remote default branch), the
@@ -3286,6 +3405,35 @@ mod tests {
         assert!(
             app.diff_filter_aborted,
             "toggle with task in flight must arm the abort flag"
+        );
+
+        // Cancel the spawned task so the test doesn't leak it.
+        if let Some(handle) = app.diff_filter_task.take() {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_evaluation_logs_timestamped_line() {
+        // The "evaluating triggers" line is pushed synchronously by
+        // `spawn_evaluation` before the background task is spawned, so it is
+        // reachable here. It was the last remaining bare `add_log` on the
+        // diff-filter path and rendered `??:??:??`.
+        let mut app = make_app();
+        app.logs.clear();
+
+        app.toggle_diff_filter();
+
+        let line = app
+            .logs
+            .iter()
+            .find(|l| l.contains("evaluating triggers"))
+            .expect("toggling the filter ON must log the evaluation start");
+        assert_ne!(
+            parsed_timestamp(line),
+            "??:??:??",
+            "evaluation-start line must carry a timestamp, got {:?}",
+            line
         );
 
         // Cancel the spawned task so the test doesn't leak it.

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -3296,6 +3296,59 @@ mod tests {
     }
 
     #[test]
+    fn diff_filter_warning_lines_survive_the_warning_filter() {
+        // The timestamp fix made these lines readable; this pins that they
+        // are also reachable. Each line is badged from the same classifier
+        // the filter uses, so a WARN-badged warning cannot be hidden by the
+        // Warning filter and an ERROR-badged parse failure cannot be hidden
+        // by the Error filter.
+        let mut app = make_app();
+        app.logs.clear();
+
+        let (tx, rx) = mpsc::channel();
+        app.diff_filter_rx = Some(rx);
+        app.diff_filter_active = true;
+        tx.send(DiffFilterOutcome::Success(DiffFilterReport {
+            rows: vec![(
+                PathBuf::from("ci.yml"),
+                Some(TriggerMatchStatus::Matched("matched ci".into())),
+            )],
+            parse_failures: vec![(
+                PathBuf::from("broken.yml"),
+                "Invalid glob pattern '[unclosed' under 'push.paths'".to_string(),
+            )],
+            warnings: vec![
+                "git ls-files --others failed (exit 128): fatal: unsafe repository".to_string(),
+            ],
+        }))
+        .unwrap();
+
+        app.check_diff_filter_results();
+
+        let warning_line = app
+            .logs
+            .iter()
+            .find(|l| l.contains("git ls-files --others failed"))
+            .expect("warning sub-item must be logged");
+        assert!(
+            crate::models::LogFilterLevel::Warning.matches(warning_line),
+            "warning sub-item is badged WARN but the Warning filter hides it: {:?}",
+            warning_line
+        );
+
+        let parse_line = app
+            .logs
+            .iter()
+            .find(|l| l.contains("broken.yml"))
+            .expect("parse-error sub-item must be logged");
+        assert!(
+            crate::models::LogFilterLevel::Error.matches(parse_line),
+            "parse-error sub-item is badged ERROR but the Error filter hides it: {:?}",
+            parse_line
+        );
+    }
+
+    #[test]
     fn check_diff_filter_results_surfaces_failure_reason_to_logs() {
         // Regression: previously, if auto_detect_context_default_base
         // errored (e.g. fresh repo with no remote default branch), the

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -1835,8 +1835,17 @@ impl App {
         all_logs
     }
 
-    /// Add a log entry and trigger log processing update
-    pub fn add_log(&mut self, message: String) {
+    /// Add a raw log entry and trigger log processing update.
+    ///
+    /// Deliberately private. Every line in the log panes is drawn with the
+    /// timestamp parsed out of its `[HH:MM:SS]` prefix, so a line pushed
+    /// without one renders `??:??:??`. Three separate fixes have been needed
+    /// for callers that reached past `add_timestamped_log` to get here;
+    /// keeping this private makes that a compile error rather than a
+    /// cosmetic bug nobody notices until a screenshot. Use
+    /// [`Self::add_timestamped_log`], and mark sub-items with
+    /// [`crate::theme::symbols::NESTED`] rather than leading whitespace.
+    fn add_log(&mut self, message: String) {
         self.logs.push(message);
         self.mark_logs_for_update(); // trims to the cap and bumps the revision
     }
@@ -2797,11 +2806,7 @@ mod tests {
     /// `[HH:MM:SS]` prefix and trims. Leading whitespace does not survive
     /// this, which is why nesting is carried by a glyph.
     fn rendered_content(line: &str) -> String {
-        crate::log_processor::LogProcessor::process_log_entry(line, "")
-            .content_spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect()
+        crate::log_processor::LogProcessor::process_log_entry(line, "").rendered_content()
     }
 
     #[test]

--- a/crates/ui/src/log_processor.rs
+++ b/crates/ui/src/log_processor.rs
@@ -1,5 +1,5 @@
 // Background log processor for asynchronous log filtering and formatting
-use crate::models::LogFilterLevel;
+use crate::models::{LogBadge, LogFilterLevel};
 use crate::theme;
 use ratatui::{
     style::Style,
@@ -221,32 +221,11 @@ impl LogProcessor {
             "??:??:??".to_string()
         };
 
-        // Determine log type and style using theme badge styles
-        let (log_type, log_style) = if log_line.contains("Error")
-            || log_line.contains("error")
-            || log_line.contains(theme::symbols::FAILURE)
-        {
-            ("ERROR", theme::log_badge("ERROR"))
-        } else if log_line.contains("Warning")
-            || log_line.contains("warning")
-            || log_line.contains(theme::symbols::WARNING)
-        {
-            ("WARN", theme::log_badge("WARN"))
-        } else if log_line.contains("Success")
-            || log_line.contains("success")
-            || log_line.contains(theme::symbols::SUCCESS)
-        {
-            ("SUCCESS", theme::log_badge("SUCCESS"))
-        } else if log_line.contains("Running")
-            || log_line.contains("running")
-            || log_line.contains(theme::symbols::RUNNING)
-        {
-            ("INFO", theme::log_badge("INFO"))
-        } else if log_line.contains("Triggering") || log_line.contains("triggered") {
-            ("TRIG", theme::log_badge("TRIG"))
-        } else {
-            ("INFO", theme::log_badge(""))
-        };
+        // Determine log type and style. `LogBadge` is shared with
+        // `LogFilterLevel::matches` so the badge drawn here and the filter
+        // that hides the line can never disagree.
+        let badge = LogBadge::classify(log_line);
+        let (log_type, log_style) = (badge.as_str(), theme::log_badge(badge.style_key()));
 
         // Extract content after timestamp
         let content = if log_line.starts_with('[') && log_line.contains(']') {

--- a/crates/ui/src/log_processor.rs
+++ b/crates/ui/src/log_processor.rs
@@ -20,6 +20,17 @@ pub struct ProcessedLogEntry {
 }
 
 impl ProcessedLogEntry {
+    /// The text the log panes actually draw, after the `[HH:MM:SS]` prefix
+    /// is stripped and the remainder trimmed. Leading whitespace does not
+    /// survive that trim, which is why nesting is carried by a glyph.
+    #[cfg(test)]
+    pub(crate) fn rendered_content(&self) -> String {
+        self.content_spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
     /// Convert to a table row for rendering
     pub fn to_row(&self) -> Row<'static> {
         Row::new(vec![
@@ -331,28 +342,18 @@ mod tests {
         // indented: the content after the `[HH:MM:SS]` prefix is trimmed, so
         // an indented line loses its nesting the moment it is timestamped.
         let indented = LogProcessor::process_log_entry("[12:34:56]   warning: x", "");
-        let rendered: String = indented
-            .content_spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect();
         assert_eq!(
-            rendered, "warning: x",
+            indented.rendered_content(),
+            "warning: x",
             "indentation must not survive the trim"
         );
 
-        let marked = LogProcessor::process_log_entry(
-            &format!("[12:34:56] {} warning: x", wrkflw_logging::symbols::NESTED),
-            "",
-        );
-        let rendered: String = marked
-            .content_spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect();
+        let nested = theme::symbols::NESTED;
+        let marked =
+            LogProcessor::process_log_entry(&format!("[12:34:56] {} warning: x", nested), "");
         assert_eq!(
-            rendered,
-            format!("{} warning: x", wrkflw_logging::symbols::NESTED),
+            marked.rendered_content(),
+            format!("{} warning: x", nested),
             "the nesting glyph must survive the trim"
         );
         assert_eq!(marked.timestamp, "12:34:56");

--- a/crates/ui/src/log_processor.rs
+++ b/crates/ui/src/log_processor.rs
@@ -324,4 +324,37 @@ mod tests {
         let entry = LogProcessor::process_log_entry("[12:34:56] some log", "");
         assert_eq!(entry.timestamp, "12:34:56");
     }
+
+    #[test]
+    fn leading_whitespace_is_trimmed_but_a_nesting_glyph_survives() {
+        // Why sub-item log lines are marked with a glyph instead of being
+        // indented: the content after the `[HH:MM:SS]` prefix is trimmed, so
+        // an indented line loses its nesting the moment it is timestamped.
+        let indented = LogProcessor::process_log_entry("[12:34:56]   warning: x", "");
+        let rendered: String = indented
+            .content_spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(
+            rendered, "warning: x",
+            "indentation must not survive the trim"
+        );
+
+        let marked = LogProcessor::process_log_entry(
+            &format!("[12:34:56] {} warning: x", wrkflw_logging::symbols::NESTED),
+            "",
+        );
+        let rendered: String = marked
+            .content_spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(
+            rendered,
+            format!("{} warning: x", wrkflw_logging::symbols::NESTED),
+            "the nesting glyph must survive the trim"
+        );
+        assert_eq!(marked.timestamp, "12:34:56");
+    }
 }

--- a/crates/ui/src/models/mod.rs
+++ b/crates/ui/src/models/mod.rs
@@ -83,6 +83,78 @@ pub enum StatusSeverity {
     Error,
 }
 
+/// The badge a log line is rendered with in the log panes.
+///
+/// This is the single source of truth for "what kind of line is this".
+/// Both the renderer (which draws the badge) and [`LogFilterLevel`]
+/// (which decides whether the line survives a filter) classify through
+/// here, so a line can never be badged `WARN` and then hidden by the
+/// Warning filter — which is exactly what happened while the two carried
+/// independent keyword lists.
+///
+/// Classification is first-match-wins in declaration order, so a line
+/// mentioning both an error and a success is an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogBadge {
+    Error,
+    Warn,
+    Success,
+    /// Active work. Rendered `INFO` with the info accent.
+    Running,
+    Trigger,
+    /// Everything else. Also rendered `INFO`, but dimmed.
+    Plain,
+}
+
+impl LogBadge {
+    /// Classify a raw log line, timestamp prefix and all.
+    pub fn classify(log: &str) -> Self {
+        if log.contains("Error") || log.contains("error") || log.contains(symbols::FAILURE) {
+            LogBadge::Error
+        } else if log.contains("Warning")
+            || log.contains("warning")
+            || log.contains(symbols::WARNING)
+        {
+            LogBadge::Warn
+        } else if log.contains("Success")
+            || log.contains("success")
+            || log.contains(symbols::SUCCESS)
+        {
+            LogBadge::Success
+        } else if log.contains("Running")
+            || log.contains("running")
+            || log.contains(symbols::RUNNING)
+        {
+            LogBadge::Running
+        } else if log.contains("Triggering") || log.contains("triggered") {
+            LogBadge::Trigger
+        } else {
+            LogBadge::Plain
+        }
+    }
+
+    /// The text drawn in the badge column.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogBadge::Error => "ERROR",
+            LogBadge::Warn => "WARN",
+            LogBadge::Success => "SUCCESS",
+            LogBadge::Running | LogBadge::Plain => "INFO",
+            LogBadge::Trigger => "TRIG",
+        }
+    }
+
+    /// The key `theme::log_badge` styles by. Distinct from [`Self::as_str`]
+    /// only for [`LogBadge::Plain`], which shares the `INFO` label but is
+    /// drawn dim so that active work stands out against routine chatter.
+    pub fn style_key(&self) -> &'static str {
+        match self {
+            LogBadge::Plain => "",
+            other => other.as_str(),
+        }
+    }
+}
+
 /// Log filter levels
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogFilterLevel {
@@ -95,20 +167,21 @@ pub enum LogFilterLevel {
 }
 
 impl LogFilterLevel {
+    /// Whether `log` survives this filter.
+    ///
+    /// Delegates to [`LogBadge::classify`] rather than matching keywords
+    /// itself: the filter must agree with the badge the user can see, or
+    /// lines disappear under the filter that names them.
     pub fn matches(&self, log: &str) -> bool {
+        let badge = LogBadge::classify(log);
         match self {
-            LogFilterLevel::Info => {
-                log.contains(symbols::INFO) || (log.contains("INFO") && !log.contains("SUCCESS"))
-            }
-            LogFilterLevel::Warning => log.contains(symbols::WARNING) || log.contains("WARN"),
-            LogFilterLevel::Error => log.contains(symbols::FAILURE) || log.contains("ERROR"),
-            LogFilterLevel::Success => {
-                log.contains(symbols::SUCCESS) || log.contains("SUCCESS") || log.contains("success")
-            }
-            LogFilterLevel::Trigger => {
-                log.contains("Triggering") || log.contains("triggered") || log.contains("TRIG")
-            }
             LogFilterLevel::All => true,
+            // Two badges are drawn `INFO`; the filter named INFO shows both.
+            LogFilterLevel::Info => matches!(badge, LogBadge::Running | LogBadge::Plain),
+            LogFilterLevel::Warning => badge == LogBadge::Warn,
+            LogFilterLevel::Error => badge == LogBadge::Error,
+            LogFilterLevel::Success => badge == LogBadge::Success,
+            LogFilterLevel::Trigger => badge == LogBadge::Trigger,
         }
     }
 
@@ -132,5 +205,95 @@ impl LogFilterLevel {
             LogFilterLevel::Success => "SUCCESS",
             LogFilterLevel::Trigger => "TRIGGER",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The invariant this type exists to hold: whatever badge the log pane
+    /// draws, the filter named after that badge must show the line.
+    /// Before `LogFilterLevel` classified through `LogBadge`, the two kept
+    /// independent keyword lists — the badge matched lowercase `warning`,
+    /// the filter only uppercase `WARN` — so the diff-filter warning lines
+    /// were badged `WARN` and then hidden by the Warning filter.
+    #[test]
+    fn every_filter_shows_the_lines_it_badges() {
+        let cases = [
+            "[12:00:00] ↳ warning: git ls-files --others failed (exit 128)",
+            "[12:00:00] ↳ parse error: broken.yml: Invalid glob pattern",
+            "[12:00:00] Diff filter: 1 warning(s)",
+            "[12:00:00] Diff filter: evaluation failed",
+            "[12:00:00] Diff filter ON: 1/2 workflows would trigger",
+            "[12:00:00] Running job 'build'",
+            "[12:00:00] Triggering workflow: ci.yml",
+            "[12:00:00] Workflow completed successfully",
+            "[12:00:00] Diff filter OFF",
+        ];
+
+        let levels = [
+            LogFilterLevel::Info,
+            LogFilterLevel::Warning,
+            LogFilterLevel::Error,
+            LogFilterLevel::Success,
+            LogFilterLevel::Trigger,
+        ];
+
+        for line in cases {
+            let badge = LogBadge::classify(line);
+            let mut shown_by = levels.iter().filter(|l| l.matches(line));
+            let level = shown_by.next().unwrap_or_else(|| {
+                panic!("no filter shows {:?} (badged {})", line, badge.as_str())
+            });
+            assert!(
+                shown_by.next().is_none(),
+                "{:?} must be shown by exactly one filter, it is badged {} once",
+                line,
+                badge.as_str()
+            );
+            assert_eq!(
+                level.as_str(),
+                match badge {
+                    LogBadge::Error => "ERROR",
+                    LogBadge::Warn => "WARNING",
+                    LogBadge::Success => "SUCCESS",
+                    LogBadge::Trigger => "TRIGGER",
+                    LogBadge::Running | LogBadge::Plain => "INFO",
+                },
+                "{:?} is badged {} but shown by the {} filter",
+                line,
+                badge.as_str(),
+                level.as_str()
+            );
+        }
+    }
+
+    /// A warning sub-item is badged WARN, so the Warning filter must keep it.
+    /// This is the line the glyph fix made visible in the first place.
+    #[test]
+    fn warning_sub_item_survives_the_warning_filter() {
+        let line = format!(
+            "[12:00:00] {} warning: git ls-files --others failed",
+            symbols::NESTED
+        );
+        assert_eq!(LogBadge::classify(&line), LogBadge::Warn);
+        assert!(LogFilterLevel::Warning.matches(&line));
+        assert!(!LogFilterLevel::Info.matches(&line));
+    }
+
+    /// `Plain` shares the `INFO` label with `Running` but not its style —
+    /// routine chatter stays dim so active work stands out.
+    #[test]
+    fn plain_is_labelled_info_but_styled_separately() {
+        assert_eq!(LogBadge::Plain.as_str(), LogBadge::Running.as_str());
+        assert_ne!(LogBadge::Plain.style_key(), LogBadge::Running.style_key());
+        assert_eq!(LogBadge::Plain.style_key(), "");
+    }
+
+    #[test]
+    fn all_shows_everything() {
+        assert!(LogFilterLevel::All.matches("[12:00:00] anything at all"));
+        assert!(LogFilterLevel::All.matches(""));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #116 and #119. Three log lines on the diff-filter path still rendered `??:??:??` in the Execution/Logs tabs:

- the two per-warning / per-parse-error sub-items in `check_diff_filter_results`
- the "Diff filter: evaluating triggers" line in `spawn_evaluation`

## Why they were left behind

`process_log_entry` extracts the timestamp from the `[HH:MM:SS]` prefix and then **trims** the content that follows. The sub-items encoded their nesting as two leading spaces, so timestamping them would have flattened them against the summary line they hang under. #116 kept the indentation and dropped the timestamp.

That's a false choice. A printable glyph survives the trim where whitespace cannot, so the nesting and the timestamp can coexist — the same trick the `curl:` recipe lines already use.

## Changes

**The timestamp fix**

- New `NESTED` symbol (`↳`, U+21B3) in `crates/logging/src/symbols.rs`, alongside the other TUI-only glyphs.
- The two sub-item sites now call `add_timestamped_log` and mark nesting with the glyph instead of two spaces.
- The "evaluating triggers" line now calls `add_timestamped_log`. It had no indentation problem, it was simply missed.

**Closing the door behind it**

`add_log` is now private. It was `pub` with exactly one caller — `add_timestamped_log` itself — and all three rounds of this bug (#116, #119, and this PR) came from a site that reached past the timestamped helper to get to it. Private makes the next attempt a compile error instead of a cosmetic bug nobody notices until a screenshot.

**The filter half of the bug**

Restoring the timestamps made these lines readable but not yet reachable: `LogFilterLevel::matches` and the badge classifier in `process_log_entry` kept independent keyword lists. The classifier matched lowercase `warning`, the filter only the uppercase `WARN` badge word — so a warning sub-item was badged `WARN` and then hidden by the Warning filter that names it.

Both now classify through a single `LogBadge` type, so the badge the user sees and the filter that keeps the line can no longer disagree. Two visible consequences, both corrections:

- Lines badged `INFO` are now shown by the INFO filter. Previously a line had to literally contain `INFO` or the `●` glyph, so most routine output was badged `INFO` and hidden by the INFO filter.
- A line is shown by exactly one filter, the one matching its badge. Previously a line containing both `error` and `success` was badged `ERROR` but surfaced under Success too.

`LogBadge::Plain` keeps the dim styling the default branch had, distinct from the `INFO` accent used for active work, so the panes look the same as before.

**Unblocking CI**

The `Clippy` job was already failing on `main` — current stable clippy flags `useless_borrows_in_formatting`, `for_kv_map`, and `question_mark` in `wrkflw-runtime` and `wrkflw-executor`, neither of which this branch otherwise touches. CI pins `dtolnay/rust-toolchain@stable` with no `rust-toolchain.toml`, so this appeared without any code change. Six mechanical fixes are folded in here so the pipeline can go green.

## Testing

- `check_diff_filter_results_timestamps_nested_sub_items` drives the real handler and asserts every line in the burst parses to a real timestamp, that sub-items carry the glyph **after** the renderer's trim, and that summary lines are not marked nested.
- `spawn_evaluation_logs_timestamped_line` covers the evaluation-start line through `toggle_diff_filter`.
- `leading_whitespace_is_trimmed_but_a_nesting_glyph_survives` pins the parser behaviour that motivates the glyph, so the reasoning does not have to live only in a comment.
- `every_filter_shows_the_lines_it_badges` walks a representative set of real log lines and asserts each is shown by exactly one filter, the one named after its badge. This is the invariant `LogBadge` exists to hold.
- `diff_filter_warning_lines_survive_the_warning_filter` ties that invariant back to the real handler: the warning sub-item must pass the Warning filter, the parse-error sub-item the Error filter.

`cargo fmt --all --check`, `cargo clippy --workspace --all-features -- -D warnings`, and `cargo test --workspace --all-features` are all clean locally.
