### PR TITLE
refactor(ui): drop the write-only WorkflowExecution.logs field

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -1,6 +1,6 @@
 # Codebase Index: wrkflw
 
-> Generated: 2026-09-08 14:45:14 UTC | Files: 202 | Lines: 71166
+> Generated: 2026-09-08 17:28:51 UTC | Files: 202 | Lines: 72893
 > Languages: JSON (4), Markdown (24), Rust (113), Shell (5), TOML (18), YAML (38)
 
 ## Directory Structure
@@ -1400,7 +1400,7 @@ wrkflw/
 
 ## INDEX.md
 
-**Language:** Markdown | **Size:** 94.2 KB | **Lines:** 4002
+**Language:** Markdown | **Size:** 145.0 KB | **Lines:** 5741
 
 **Declarations:**
 
@@ -3622,7 +3622,7 @@ wrkflw/
 
 ## crates/ui/src/app/state.rs
 
-**Language:** Rust | **Size:** 177.5 KB | **Lines:** 4398
+**Language:** Rust | **Size:** 176.9 KB | **Lines:** 4388
 
 **Imports:**
 - `crate::log_processor::{LogProcessingRequest, LogProcessor, ProcessedLogEntry}`
@@ -4030,7 +4030,7 @@ wrkflw/
 
 ## crates/ui/src/handlers/workflow.rs
 
-**Language:** Rust | **Size:** 25.3 KB | **Lines:** 667
+**Language:** Rust | **Size:** 25.3 KB | **Lines:** 666
 
 **Imports:**
 - `crate::cli_style`
@@ -4115,7 +4115,7 @@ wrkflw/
 
 ## crates/ui/src/models/mod.rs
 
-**Language:** Rust | **Size:** 10.9 KB | **Lines:** 314
+**Language:** Rust | **Size:** 10.9 KB | **Lines:** 313
 
 **Imports:**
 - `chrono::Local`

--- a/crates/ui/src/app/state.rs
+++ b/crates/ui/src/app/state.rs
@@ -1178,7 +1178,6 @@ impl App {
                 jobs: Vec::new(),
                 start_time: Local::now(),
                 end_time: Some(Local::now()),
-                logs: Vec::new(),
                 progress: 1.0,
             });
         }
@@ -1189,10 +1188,6 @@ impl App {
 
             match &result {
                 Ok((jobs, _)) => {
-                    let timestamp = Local::now().format("%H:%M:%S").to_string();
-                    execution_details
-                        .logs
-                        .push(format!("[{}] Operation completed successfully.", timestamp));
                     execution_details.progress = 1.0;
 
                     // Convert wrkflw_executor::JobResult to our JobExecution struct
@@ -1223,10 +1218,6 @@ impl App {
                         .collect::<Vec<JobExecution>>();
                 }
                 Err(e) => {
-                    let timestamp = Local::now().format("%H:%M:%S").to_string();
-                    execution_details
-                        .logs
-                        .push(format!("[{}] Error: {}", timestamp, e));
                     execution_details.progress = 1.0;
 
                     // Create a dummy job with the error information so users can see details
@@ -1290,7 +1281,6 @@ impl App {
             jobs: Vec::new(),
             start_time: Local::now(),
             end_time: None,
-            logs: vec!["Execution started".to_string()],
             progress: 0.0, // Just started
         });
 

--- a/crates/ui/src/handlers/workflow.rs
+++ b/crates/ui/src/handlers/workflow.rs
@@ -564,7 +564,6 @@ pub fn start_next_workflow_execution(
                 jobs: Vec::new(),
                 start_time: Local::now(),
                 end_time: None,
-                logs: Vec::new(),
                 progress: 0.0,
             });
         }

--- a/crates/ui/src/models/mod.rs
+++ b/crates/ui/src/models/mod.rs
@@ -54,7 +54,6 @@ pub struct WorkflowExecution {
     pub jobs: Vec<JobExecution>,
     pub start_time: chrono::DateTime<Local>,
     pub end_time: Option<chrono::DateTime<Local>>,
-    pub logs: Vec<String>,
     pub progress: f64, // 0.0 - 1.0 for progress bar
 }
 


### PR DESCRIPTION
TODO item 4 (`P3`, refactor) from the follow-up list off the PR #116 review. Fourth and last item in that series, after #119, #127 and #128.

## What the item asked for, and why this PR does something else

The item was written against a pre-#119 tree. It asked to delete the ad-hoc `trim_logs_to_cap()` calls in `check_diff_filter_results`, rewrite the stale comment block above them, and route ~7 hand-rolled `Local::now().format("%H:%M:%S")` sites through `add_timestamped_log`.

Auditing that against current `main`:

- **The trim calls and the stale comment are already gone.** #119 removed all six ad-hoc calls and the "Ad-hoc `self.logs.push(...)`" comment. The single surviving call lives in `mark_logs_for_update`, which is the choke point every log mutation routes through — it belongs there.
- **Only three of the ~7 timestamp sites survived.** One is `add_timestamped_log` itself. The other two are in `process_execution_result`, and they write to `WorkflowExecution.logs` — not to the app log buffer.

`WorkflowExecution.logs` has five writers and zero readers. Every view that touches `execution_details` renders `.jobs`, `.start_time` or `.progress`; none of them read `.logs`.

Doing what the item literally said would have been a regression. Both arms of `process_execution_result` already report their outcome through `wrkflw_logging`, and `get_combined_logs` merges that store into the app buffer without deduplicating. Routing those two pushes through `add_timestamped_log` would have rendered each outcome twice — precisely the dual logging #128 removed — and would have failed the `dual_logged_events_do_not_also_land_in_the_app_buffer` test that #128 added.

So the dead field goes instead.

## Changes

- Delete `WorkflowExecution.logs` (`crates/ui/src/models/mod.rs`).
- Delete its five writers: three struct constructors (two in `app/state.rs`, one in `handlers/workflow.rs`) and the two `execution_details.logs.push(...)` calls in `process_execution_result`.
- Regenerate `INDEX.md`.

Net 12 deletions, zero insertions of logic. Exactly one `[HH:MM:SS]` format site now remains in `state.rs`, inside `add_timestamped_log`.

## Behaviour

No user-visible change. The deleted field was never rendered, and the workflow outcome lines it duplicated continue to reach the Logs and Execution tabs through the global store.

## Verification

All four CI commands pass with zero failures:

```
cargo fmt --check
cargo clippy --workspace --all-features -- -D warnings
cargo check --no-default-features --workspace
cargo test --workspace --all-features
```

Full workspace suite green, including all 68 tests in `wrkflw-ui`. No test changes were needed — the existing dual-logging test keeps guarding the app-side behaviour.

## Follow-up

`JobExecution.logs` is dead in the same way: two writers, no readers. Left out of this PR to keep it scoped to what item 4 named, and because one of its writers carries real per-job executor output that deserves a check before deletion. Filed as item 5.